### PR TITLE
Add Bank of Anthos ASM sample manifests

### DIFF
--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/README.md
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/README.md
@@ -1,0 +1,3 @@
+# Bank of Anthos ASM Demo Manifests
+
+This directory contains demo manifests for Anthos Service Mesh Traffic Management capabilities for the [Bank of Anthos](https://github.com/GoogleCloudPlatform/bank-of-anthos).

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-100-0.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-100-0.yml
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_frontend ]
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: frontend
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bank-of-anthos-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: frontend
+        subset: v0-2-0
+      weight: 0
+    - destination:
+        host: frontend
+        subset: v0-2-0-custom
+      weight: 100
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_frontend ]

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-50-50.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-50-50.yml
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_frontend ]
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: frontend
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bank-of-anthos-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: frontend
+        subset: v0-2-0
+      weight: 50
+    - destination:
+        host: frontend
+        subset: v0-2-0-custom
+      weight: 50
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_frontend ]

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-deployment.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-deployment.yml
@@ -1,0 +1,100 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_deployment_frontend-custom ]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-custom
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+        version: v0.2.0-custom
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: front
+        # Temporarily use this container image until https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/235 is merged
+        image: gcr.io/bjm-public-container-images/bank-of-anthos/frontend-temp@sha256:d252c140896fc6b87681f6cf81e7084cf95f8e82d1dd9b1a42ea5f3fd2b41dd2
+        volumeMounts:
+        - name: publickey
+          mountPath: "/root/.ssh"
+          readOnly: true
+        env:
+        - name: VERSION
+          value: "v0.2.0-custom"
+        - name: PORT
+          value: "8080"
+        - name: BANK_NAME
+          value: "Bank of Custom"
+        - name: DEFAULT_USERNAME
+          valueFrom:
+            configMapKeyRef:
+              name: default-data-config
+              key: DEFAULT_USER_USERNAME
+        - name: DEFAULT_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: default-data-config
+              key: DEFAULT_LOGIN_PASSWORD
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: service-api-config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+# [END anthos-service-mesh_bank-of-anthos_deployment_frontend-custom ]
+---
+# [START anthos-service-mesh_bank-of-anthos_destinationrule_frontend-destination ]
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: frontend-destination
+spec:
+  host: frontend
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0
+  - name: v0-2-0-custom
+    labels:
+      version: v0.2.0-custom
+# [END anthos-service-mesh_bank-of-anthos_destinationrule_frontend-destination ]

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-http-header.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-http-header.yml
@@ -1,0 +1,43 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_frontend ]
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: frontend
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bank-of-anthos-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+      headers:
+        X-Beta-Tester:
+          exact: "true"
+    route:
+    - destination:
+        host: frontend
+        subset: v0-2-0-custom
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: frontend
+        subset: v0-2-0
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_frontend ]

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-delay-fault-injection.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-delay-fault-injection.yml
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_frontend ]
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: frontend
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bank-of-anthos-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: frontend
+        subset: v0-2-0
+    fault:
+      delay:
+        fixedDelay: 10s
+        percentage:
+          value: 50
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_frontend ]

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-http500-fault-injection.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-http500-fault-injection.yml
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_frontend ]
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: frontend
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bank-of-anthos-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: frontend
+        subset: v0-2-0
+    fault:
+      abort:
+        httpStatus: 500
+        percentage:
+          value: 50
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_frontend ]

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/README.md
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/README.md
@@ -1,0 +1,3 @@
+# Bank of Anthos ASM Deployment Manifests
+
+This directory contains standard deployment manifests for the [Bank of Anthos](https://github.com/GoogleCloudPlatform/bank-of-anthos) application with Anthos Service Mesh Support.

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/accounts-db.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/accounts-db.yaml
@@ -1,0 +1,128 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_statefulset_accounts-db ]
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: accounts-db
+  labels:
+    app: accounts-db
+    tier: db
+spec:
+  serviceName: "accounts-db"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: accounts-db
+      tier: db
+  template:
+    metadata:
+      labels:
+        app: accounts-db
+        tier: db
+        version: v0.2.0
+    spec:
+      containers:
+      - name: accounts-db
+        image: gcr.io/bank-of-anthos/accounts-db:latest
+        envFrom:
+          - configMapRef:
+              name: environment-config
+          - configMapRef:
+              name: accounts-db-config
+          - configMapRef:
+              name: default-data-config
+        ports:
+          - containerPort: 5432
+            name: postgredb
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        volumeMounts:
+        - name: postgresdb
+          mountPath: /var/lib/postgresql/data
+          subPath: postgres
+      volumes:
+      - name: postgresdb
+        emptyDir: {}
+# [END anthos-service-mesh_bank-of-anthos_statefulset_accounts-db ]
+---
+# [START anthos-service-mesh_bank-of-anthos_service_accounts-db ]
+apiVersion: v1
+kind: Service
+metadata:
+  name: accounts-db
+  labels:
+    app: accounts-db
+    tier: db
+spec:
+  ports:
+    - port: 5432
+      name: tcp-postgredb
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    app: accounts-db
+    tier: db
+# [END anthos-service-mesh_bank-of-anthos_service_accounts-db ]
+---
+# [START anthos-service-mesh_bank-of-anthos_configmap_accounts-db-config ]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: accounts-db-config
+  labels:
+    app: accounts-db
+data:
+  POSTGRES_DB: accounts-db
+  POSTGRES_USER: accounts-admin
+  POSTGRES_PASSWORD: accounts-pwd
+  ACCOUNTS_DB_URI: postgresql://accounts-admin:accounts-pwd@accounts-db:5432/accounts-db
+# [END anthos-service-mesh_bank-of-anthos_configmap_accounts-db-config ]
+---
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_accounts-db ]
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: accounts-db
+spec:
+  hosts:
+  - accounts-db
+  tcp:
+  - route:
+    - destination:
+        host: accounts-db
+        subset: v0-2-0
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_accounts-db ]
+---
+# [START anthos-service-mesh_bank-of-anthos_destinationrule_accounts-db-destination ]
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: accounts-db-destination
+spec:
+  host: accounts-db
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0
+# [END anthos-service-mesh_bank-of-anthos_destinationrule_accounts-db-destination ]

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/asm-gateway.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/asm-gateway.yaml
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_gateway_bank-of-anthos-gateway ]
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: bank-of-anthos-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*" 
+# [END anthos-service-mesh_bank-of-anthos_gateway_bank-of-anthos-gateway ]

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/balance-reader.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/balance-reader.yaml
@@ -1,0 +1,128 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_deployment_balancereader ]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: balancereader
+spec:
+  selector:
+    matchLabels:
+      app: balancereader
+  template:
+    metadata:
+      labels:
+        app: balancereader
+        version: v0.2.0
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: reader
+        image: gcr.io/bank-of-anthos/balancereader:latest
+        volumeMounts:
+        - name: publickey
+          mountPath: "/root/.ssh"
+          readOnly: true
+        env:
+        - name: VERSION
+          value: "v0.2.0"
+        - name: PORT
+          value: "8080"
+        - name: POLL_MS
+          value: "100"
+        - name: CACHE_SIZE
+          value: "1000000"
+        # tell Java to obey container memory limits
+        - name: JVM_OPTS
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        # add ledger-db credentials from ConfigMap
+        - configMapRef:
+            name: ledger-db-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 5
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+# [END anthos-service-mesh_bank-of-anthos_deployment_balancereader ]
+---
+# [START anthos-service-mesh_bank-of-anthos_service_balancereader ]
+apiVersion: v1
+kind: Service
+metadata:
+  name: balancereader
+spec:
+  type: ClusterIP
+  selector:
+    app: balancereader
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END anthos-service-mesh_bank-of-anthos_service_balancereader ]
+---
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_balancereader ]
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: balancereader
+spec:
+  hosts:
+  - balancereader
+  http:
+  - route:
+    - destination:
+        host: balancereader
+        subset: v0-2-0
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_balancereader ]
+---
+# [START anthos-service-mesh_bank-of-anthos_destinationrule_balancereader-destination ]
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: balancereader-destination
+spec:
+  host: balancereader
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0
+# [END anthos-service-mesh_bank-of-anthos_destinationrule_balancereader-destination ]

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/config.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/config.yaml
@@ -1,0 +1,53 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_configmap_environment-config ]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: environment-config
+data:
+  LOCAL_ROUTING_NUM: "123456789"
+  PUB_KEY_PATH: "/root/.ssh/publickey"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-api-config
+data:
+  TRANSACTIONS_API_ADDR: "ledgerwriter:8080"
+  BALANCES_API_ADDR: "balancereader:8080"
+  HISTORY_API_ADDR: "transactionhistory:8080"
+  CONTACTS_API_ADDR: "contacts:8080"
+  USERSERVICE_API_ADDR: "userservice:8080"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-data-config
+data:
+  USE_DEFAULT_DATA: "True"
+  # All default user accounts are hardcoded to use the login password 'password'
+  DEFAULT_LOGIN_PASSWORD: "password"
+  DEFAULT_USER_ACCOUNT: "1033623433"
+  DEFAULT_USER_USERNAME: "testuser"
+  DEFAULT_USER_NAME: "Eve"
+  DEFAULT_DEPOSIT_ACCOUNT: "9099791699"
+  DEFAULT_DEPOSIT_ROUTING: "808889588"
+  DEFAULT_DEPOSIT_LABEL: "External Bank"
+  DEFAULT_CONTACT_ACCOUNT_A: "1044226144"
+  DEFAULT_CONTACT_NAME_A: "Alice"
+  DEFAULT_CONTACT_ACCOUNT_B: "1055757655"
+  DEFAULT_CONTACT_NAME_B: "Bob"
+# [END anthos-service-mesh_bank-of-anthos_configmap_environment-config ]

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/contacts.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/contacts.yaml
@@ -1,0 +1,114 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_deployment_contacts ]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: contacts
+spec:
+  selector:
+    matchLabels:
+      app: contacts
+  template:
+    metadata:
+      labels:
+        app: contacts
+        version: v0.2.0
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: contacts
+        image: gcr.io/bank-of-anthos/contacts:latest
+        volumeMounts:
+        - name: publickey
+          mountPath: "/root/.ssh"
+          readOnly: true
+        env:
+        - name: VERSION
+          value: "v0.2.0"
+        - name: PORT
+          value: "8080"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: accounts-db-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+# [END anthos-service-mesh_bank-of-anthos_deployment_contacts ]
+---
+# [START anthos-service-mesh_bank-of-anthos_service_contacts ]
+apiVersion: v1
+kind: Service
+metadata:
+  name: contacts
+spec:
+  type: ClusterIP
+  selector:
+    app: contacts
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [end anthos-service-mesh_bank-of-anthos_service_contacts ]
+---
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_contacts ]
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: contacts
+spec:
+  hosts:
+  - contacts
+  http:
+  - route:
+    - destination:
+        host: contacts
+        subset: v0-2-0
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_contacts ]
+---
+# [START anthos-service-mesh_bank-of-anthos_destinationrule_contacts-destination ]
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: contacts-destination
+spec:
+  host: contacts
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0
+# [END anthos-service-mesh_bank-of-anthos_destinationrule_contacts-destination ]

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/frontend.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/frontend.yaml
@@ -1,0 +1,129 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_deployment_frontend ]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+        version: v0.2.0
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: front
+        image: gcr.io/bank-of-anthos/frontend:latest
+        volumeMounts:
+        - name: publickey
+          mountPath: "/root/.ssh"
+          readOnly: true
+        env:
+        - name: VERSION
+          value: "v0.2.0"
+        - name: PORT
+          value: "8080"
+        - name: DEFAULT_USERNAME
+          valueFrom:
+            configMapKeyRef:
+              name: default-data-config
+              key: DEFAULT_USER_USERNAME
+        - name: DEFAULT_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: default-data-config
+              key: DEFAULT_LOGIN_PASSWORD
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: service-api-config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+# [END anthos-service-mesh_bank-of-anthos_deployment_frontend ]
+---
+# [START anthos-service-mesh_bank-of-anthos_service_frontend ]
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+# [END anthos-service-mesh_bank-of-anthos_service_frontend ]
+---
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_frontend ]
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: frontend
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bank-of-anthos-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: frontend
+        subset: v0-2-0
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_frontend ]
+---
+# [START anthos-service-mesh_bank-of-anthos_destinationrule_frontend-destination ]
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: frontend-destination
+spec:
+  host: frontend
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0
+# [END anthos-service-mesh_bank-of-anthos_destinationrule_frontend-destination ]

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-db.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-db.yaml
@@ -1,0 +1,120 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_statefulset_ledger-db ]
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: ledger-db
+spec:
+  serviceName: "ledger-db"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ledger-db
+  template:
+    metadata:
+      labels:
+        app: ledger-db
+        version: v0.2.0
+    spec:
+      containers:
+        - name: postgres
+          image: gcr.io/bank-of-anthos/ledger-db:latest
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - configMapRef:
+                name: environment-config
+            - configMapRef:
+                name: ledger-db-config
+            - configMapRef:
+                name: default-data-config
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: postgresdb
+              mountPath: /var/lib/postgresql/data
+              subPath: postgres
+      volumes:
+        - name: postgresdb
+          emptyDir: {}
+# [END anthos-service-mesh_bank-of-anthos_statefulset_ledger-db ]
+---
+# [START anthos-service-mesh_bank-of-anthos_configmap_ledger-db-config ]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ledger-db-config
+  labels:
+    app: postgres
+data:
+  POSTGRES_DB: postgresdb
+  POSTGRES_USER: admin
+  POSTGRES_PASSWORD: password
+  SPRING_DATASOURCE_URL: jdbc:postgresql://ledger-db:5432/postgresdb
+  SPRING_DATASOURCE_USERNAME: admin # should match POSTGRES_USER
+  SPRING_DATASOURCE_PASSWORD: password # should match POSTGRES_PASSWORD
+# [END anthos-service-mesh_bank-of-anthos_configmap_ledger-db-config ]
+---
+# [START anthos-service-mesh_bank-of-anthos_service_ledger-db-config ]
+apiVersion: v1
+kind: Service
+metadata:
+  name: ledger-db
+spec:
+  type: ClusterIP
+  selector:
+    app: ledger-db
+  ports:
+  - name: tcp-postgres
+    port: 5432
+    targetPort: 5432
+# [END anthos-service-mesh_bank-of-anthos_service_ledger-db-config ]
+---
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_ledger-db ]
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ledger-db
+spec:
+  hosts:
+  - ledger-db
+  tcp:
+  - route:
+    - destination:
+        host: ledger-db
+        subset: v0-2-0
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_ledger-db ]
+---
+# [START anthos-service-mesh_bank-of-anthos_destinationrule_ledger-db-destination ]
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: ledger-db-destination
+spec:
+  host: ledger-db
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0
+# [END anthos-service-mesh_bank-of-anthos_destinationrule_ledger-db-destination ]

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-writer.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-writer.yaml
@@ -1,0 +1,120 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_deployment_ledgerwriter ]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ledgerwriter
+spec:
+  selector:
+    matchLabels:
+      app: ledgerwriter
+  template:
+    metadata:
+      labels:
+        app: ledgerwriter
+        version: v0.2.0
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: writer
+        image: gcr.io/bank-of-anthos/ledgerwriter:latest
+        volumeMounts:
+        - name: publickey
+          mountPath: "/root/.ssh"
+          readOnly: true
+        env:
+        - name: VERSION
+          value: "v0.2.0"
+        - name: PORT
+          value: "8080"
+         # tell Java to obey container memory limits
+        - name: JVM_OPTS
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: service-api-config
+        # add ledger-db credentials from ConfigMap
+        - configMapRef:
+            name: ledger-db-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+# [END anthos-service-mesh_bank-of-anthos_deployment_ledgerwriter ]
+---
+# [START anthos-service-mesh_bank-of-anthos_service_ledgerwriter ]
+apiVersion: v1
+kind: Service
+metadata:
+  name: ledgerwriter
+spec:
+  type: ClusterIP
+  selector:
+    app: ledgerwriter
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END anthos-service-mesh_bank-of-anthos_service_ledgerwriter ]
+---
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_ledgerwriter ]
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ledgerwriter
+spec:
+  hosts:
+  - ledgerwriter
+  http:
+  - route:
+    - destination:
+        host: ledgerwriter
+        subset: v0-2-0
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_ledgerwriter ]
+---
+# [START anthos-service-mesh_bank-of-anthos_destinationrule_ledgerwriter-destination ]
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: ledgerwriter-destination
+spec:
+  host: ledgerwriter
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0
+# [END anthos-service-mesh_bank-of-anthos_destinationrule_ledgerwriter-destination ]

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/loadgenerator.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/loadgenerator.yaml
@@ -1,0 +1,49 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_deployment_loadgenerator ]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadgenerator
+spec:
+  selector:
+    matchLabels:
+      app: loadgenerator
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: loadgenerator
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    spec:
+      terminationGracePeriodSeconds: 5
+      restartPolicy: Always
+      containers:
+      - name: main
+        image: gcr.io/bank-of-anthos/loadgenerator:latest
+        env:
+        - name: FRONTEND_ADDR
+          value: "frontend:80"
+        - name: USERS
+          value: "5"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+# [END anthos-service-mesh_bank-of-anthos_deployment_loadgenerator ]

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/transaction-history.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/transaction-history.yaml
@@ -1,0 +1,134 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_deployment_transactionhistory ]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transactionhistory
+spec:
+  selector:
+    matchLabels:
+      app: transactionhistory
+  template:
+    metadata:
+      labels:
+        app: transactionhistory
+        version: v0.2.0
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: history
+        image: gcr.io/bank-of-anthos/transactionhistory:latest
+        volumeMounts:
+        - name: publickey
+          mountPath: "/root/.ssh"
+          readOnly: true
+        env:
+        - name: VERSION
+          value: "v0.2.0"
+        - name: PORT
+          value: "8080"
+        - name: POLL_MS
+          value: "100"
+        - name: CACHE_SIZE
+          value: "1000"
+        - name: CACHE_MINUTES
+          value: "60"
+        - name: HISTORY_LIMIT
+          value: "100"
+          # tell Java to obey container memory limits
+        - name: JVM_OPTS
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+        #- name: EXTRA_LATENCY_MILLIS
+        #  value: "5000"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        # add ledger-db credentials from ConfigMap
+        - configMapRef:
+            name: ledger-db-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 5
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+# [END anthos-service-mesh_bank-of-anthos_deployment_transactionhistory ]
+---
+# [START anthos-service-mesh_bank-of-anthos_service_transactionhistory ]
+apiVersion: v1
+kind: Service
+metadata:
+  name: transactionhistory
+spec:
+  type: ClusterIP
+  selector:
+    app: transactionhistory
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END anthos-service-mesh_bank-of-anthos_service_transactionhistory ]
+---
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_transactionhistory ]
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: transactionhistory
+spec:
+  hosts:
+  - transactionhistory
+  http:
+  - route:
+    - destination:
+        host: transactionhistory
+        subset: v0-2-0
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_transactionhistory ]
+---
+# [START anthos-service-mesh_bank-of-anthos_destinationrule_transactionhistory-destination ]
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: transactionhistory-destination
+spec:
+  host: transactionhistory
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0
+# [END anthos-service-mesh_bank-of-anthos_destinationrule_transactionhistory-destination ]

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/userservice.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/userservice.yaml
@@ -1,0 +1,123 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthos-service-mesh_bank-of-anthos_deployment_userservice ]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: userservice
+spec:
+  selector:
+    matchLabels:
+      app: userservice
+  template:
+    metadata:
+      labels:
+        app: userservice
+        version: v0.2.0
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: userservice
+        image: gcr.io/bank-of-anthos/userservice:latest
+        volumeMounts:
+        - name: keys
+          mountPath: "/root/.ssh"
+          readOnly: true
+        ports:
+        - name: http-server
+          containerPort: 8080
+        env:
+        - name: VERSION
+          value: "v0.2.0"
+        - name: PORT
+          value: "8080"
+        - name: TOKEN_EXPIRY_SECONDS
+          value: "3600"
+        - name: PRIV_KEY_PATH
+          value: "/root/.ssh/privatekey"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: accounts-db-config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+      volumes:
+      - name: keys
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key
+            path: privatekey
+          - key: jwtRS256.key.pub
+            path: publickey
+# [END anthos-service-mesh_bank-of-anthos_deployment_userservice ]
+---
+# [START anthos-service-mesh_bank-of-anthos_service_userservice ]
+apiVersion: v1
+kind: Service
+metadata:
+  name: userservice
+spec:
+  type: ClusterIP
+  selector:
+    app: userservice
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END anthos-service-mesh_bank-of-anthos_service_userservice ]
+---
+# [START anthos-service-mesh_bank-of-anthos_virtualservice_userservice ]  
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: userservice
+spec:
+  hosts:
+  - userservice
+  http:
+  - route:
+    - destination:
+        host: userservice
+        subset: v0-2-0
+# [END anthos-service-mesh_bank-of-anthos_virtualservice_userservice ]  
+---
+# [START anthos-service-mesh_bank-of-anthos_destinationrule_userservice-destination ]  
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: userservice-destination
+spec:
+  host: userservice
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0
+# [END anthos-service-mesh_bank-of-anthos_destinationrule_userservice-destination ]  


### PR DESCRIPTION
This Pull Request is to include sample Istio/ASM manifests for the Bank of Anthos application.

There are two sets of manifests:

1. Deployment manifests - Used for a standard BOA deployment with the associated Istio resources 
2. Demo manifests - Used to demonstrate some of the Traffic Management capabilities of Istio.

Region tags are included.