### PR TITLE
v1.5 snippets: enabling optional features

### DIFF
--- a/docs/enabling-optional-features/cloud_trace_addoncomponents.yaml
+++ b/docs/enabling-optional-features/cloud_trace_addoncomponents.yaml
@@ -1,0 +1,26 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START servicemesh_cloud_trace_addoncomponents]
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  addonComponents:
+    tracing:
+      enabled: true
+  values:
+    global:
+      proxy:
+        tracer: "stackdriver"
+# [END servicemesh_cloud_trace_addoncomponents]

--- a/docs/enabling-optional-features/direct_envoy_stdout_proxy.yaml
+++ b/docs/enabling-optional-features/direct_envoy_stdout_proxy.yaml
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START servicemesh_direct_envoy_stdout_proxy]
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  global:
+    proxy:
+      accessLogFile="/dev/stdout"
+# [END servicemesh_direct_envoy_stdout_proxy]

--- a/docs/enabling-optional-features/mtls_strict_mode.yaml
+++ b/docs/enabling-optional-features/mtls_strict_mode.yaml
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START servicemesh_mtls_strict_mode]
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  global:
+    mtls:
+      enabled: true
+# [END servicemesh_mtls_strict_mode]


### PR DESCRIPTION
https://cloud.google.com/service-mesh/docs/archive/1.5/docs/enable-optional-features

The rest of this document's snippets are included in v1.6 #2 