### PR TITLE
Reverse CODEOWNERS order

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,6 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-*                          @GoogleCloudPlatform/anthos-dpe
-
 /docs/mtls-egress-ingress/ @vhamburger @jeremysolarz
+
+*                          @GoogleCloudPlatform/anthos-dpe


### PR DESCRIPTION
According to the Github CODEOWNERS documentation -- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Later items in the file take precedence. Reversing the order here so that anthos-dpe can be sole approver on any Pull Request, including the ones outside of the mtls sample owned by Jeremy and Valentin. 