### PR TITLE
Update to boa v0.5.3

### DIFF
--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-100-0.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-100-0.yml
@@ -30,11 +30,11 @@ spec:
     route:
     - destination:
         host: frontend
-        subset: v0-2-0
+        subset: v0-5-2
       weight: 0
     - destination:
         host: frontend
-        subset: v0-2-0-custom
+        subset: v0-5-2-custom
       weight: 100
 # [END servicemesh_demo_manifests_frontend_custom_100_0_virtualservice_frontend]
 ---

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-100-0.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-100-0.yml
@@ -30,11 +30,11 @@ spec:
     route:
     - destination:
         host: frontend
-        subset: v0-5-2
+        subset: v0-5-3
       weight: 0
     - destination:
         host: frontend
-        subset: v0-5-2-custom
+        subset: v0-5-3-custom
       weight: 100
 # [END servicemesh_demo_manifests_frontend_custom_100_0_virtualservice_frontend]
 ---

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-50-50.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-50-50.yml
@@ -30,11 +30,11 @@ spec:
     route:
     - destination:
         host: frontend
-        subset: v0-5-2
+        subset: v0-5-3
       weight: 50
     - destination:
         host: frontend
-        subset: v0-5-2-custom
+        subset: v0-5-3-custom
       weight: 50
 # [END servicemesh_demo_manifests_frontend_custom_50_50_virtualservice_frontend]
 ---

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-50-50.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-50-50.yml
@@ -30,11 +30,11 @@ spec:
     route:
     - destination:
         host: frontend
-        subset: v0-2-0
+        subset: v0-5-2
       weight: 50
     - destination:
         host: frontend
-        subset: v0-2-0-custom
+        subset: v0-5-2-custom
       weight: 50
 # [END servicemesh_demo_manifests_frontend_custom_50_50_virtualservice_frontend]
 ---

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-deployment.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-deployment.yml
@@ -26,20 +26,20 @@ spec:
     metadata:
       labels:
         app: frontend
-        version: v0.5.2-custom
+        version: v0.5.3-custom
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.3
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.2-custom"
+          value: "v0.5.3-custom"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
@@ -111,11 +111,11 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-5-2
+  - name: v0-5-3
     labels:
-      version: v0.5.2
-  - name: v0-5-2-custom
+      version: v0.5.3
+  - name: v0-5-3-custom
     labels:
-      version: v0.5.2-custom
+      version: v0.5.3-custom
 # [END servicemesh_demo_manifests_frontend_custom_deployment_destinationrule_frontend_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-deployment.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-deployment.yml
@@ -28,32 +28,43 @@ spec:
         app: frontend
         version: v0.2.0-custom
     spec:
+      serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        # Temporarily use this container image until https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/235 is merged
-        image: gcr.io/bjm-public-container-images/bank-of-anthos/frontend-temp@sha256:d252c140896fc6b87681f6cf81e7084cf95f8e82d1dd9b1a42ea5f3fd2b41dd2
+        image: gcr.io/bank-of-anthos-ci/frontend:latest
         volumeMounts:
         - name: publickey
-          mountPath: /root/.ssh
+          mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: v0.2.0-custom
+          value: "v0.5.2"
         - name: PORT
-          value: '8080'
+          value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
+        - name: SCHEME
+          value: "http"
+         # Valid levels are debug, info, warning, error, critical. If no valid level is set, gunicorn will default to info.
+        - name: LOG_LEVEL
+          value: "info"
+        # Set to "true" to enable the CymbalBank logo + title
+        # - name: CYMBAL_LOGO
+        #   value: "false"
+        # Customize the bank name used in the header. Defaults to 'Bank of Anthos' - when CYMBAL_LOGO is true, uses 'CymbalBank'
         - name: BANK_NAME
-          value: Bank of Custom
+          value: "Bank of Custom"
         - name: DEFAULT_USERNAME
           valueFrom:
             configMapKeyRef:
-              name: default-data-config
-              key: DEFAULT_USER_USERNAME
+              name: demo-data-config
+              key: DEMO_LOGIN_USERNAME
         - name: DEFAULT_PASSWORD
           valueFrom:
             configMapKeyRef:
-              name: default-data-config
-              key: DEFAULT_LOGIN_PASSWORD
+              name: demo-data-config
+              key: DEMO_LOGIN_PASSWORD
         envFrom:
         - configMapRef:
             name: environment-config
@@ -63,8 +74,16 @@ spec:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 30
         resources:
           requests:
             cpu: 100m

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-deployment.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-deployment.yml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos-ci/frontend:latest
+        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-deployment.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-deployment.yml
@@ -26,7 +26,7 @@ spec:
     metadata:
       labels:
         app: frontend
-        version: v0.2.0-custom
+        version: v0.5.2-custom
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -39,7 +39,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.2"
+          value: "v0.5.2-custom"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
@@ -111,11 +111,11 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-2-0
+  - name: v0-5-2
     labels:
-      version: v0.2.0
-  - name: v0-2-0-custom
+      version: v0.5.2
+  - name: v0-5-2-custom
     labels:
-      version: v0.2.0-custom
+      version: v0.5.2-custom
 # [END servicemesh_demo_manifests_frontend_custom_deployment_destinationrule_frontend_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-http-header.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-http-header.yml
@@ -33,13 +33,13 @@ spec:
     route:
     - destination:
         host: frontend
-        subset: v0-5-2-custom
+        subset: v0-5-3-custom
   - match:
     - uri:
         prefix: /
     route:
     - destination:
         host: frontend
-        subset: v0-5-2
+        subset: v0-5-3
 # [END servicemesh_demo_manifests_frontend_custom_http_header_virtualservice_frontend]
 ---

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-http-header.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-custom-http-header.yml
@@ -33,13 +33,13 @@ spec:
     route:
     - destination:
         host: frontend
-        subset: v0-2-0-custom
+        subset: v0-5-2-custom
   - match:
     - uri:
         prefix: /
     route:
     - destination:
         host: frontend
-        subset: v0-2-0
+        subset: v0-5-2
 # [END servicemesh_demo_manifests_frontend_custom_http_header_virtualservice_frontend]
 ---

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-delay-fault-injection.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-delay-fault-injection.yml
@@ -30,7 +30,7 @@ spec:
     route:
     - destination:
         host: frontend
-        subset: v0-2-0
+        subset: v0-5-2
     fault:
       delay:
         fixedDelay: 10s

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-delay-fault-injection.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-delay-fault-injection.yml
@@ -30,7 +30,7 @@ spec:
     route:
     - destination:
         host: frontend
-        subset: v0-5-2
+        subset: v0-5-3
     fault:
       delay:
         fixedDelay: 10s

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-http500-fault-injection.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-http500-fault-injection.yml
@@ -30,7 +30,7 @@ spec:
     route:
     - destination:
         host: frontend
-        subset: v0-2-0
+        subset: v0-5-2
     fault:
       abort:
         httpStatus: 500

--- a/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-http500-fault-injection.yml
+++ b/demos/bank-of-anthos-asm-manifests/demo-manifests/frontend-http500-fault-injection.yml
@@ -30,7 +30,7 @@ spec:
     route:
     - destination:
         host: frontend
-        subset: v0-5-2
+        subset: v0-5-3
     fault:
       abort:
         httpStatus: 500

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/accounts-db.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/accounts-db.yaml
@@ -33,12 +33,12 @@ spec:
       labels:
         app: accounts-db
         tier: db
-        version: v0.5.2
+        version: v0.5.3
     spec:
       serviceAccountName: default
       containers:
       - name: accounts-db
-        image: gcr.io/bank-of-anthos-ci/accounts-db:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/accounts-db:v0.5.3
         envFrom:
           - configMapRef:
               name: environment-config
@@ -110,7 +110,7 @@ spec:
   - route:
     - destination:
         host: accounts-db
-        subset: v0-5-2
+        subset: v0-5-3
 # [END servicemesh_deployment_manifests_accounts_db_virtualservice_accounts_db]
 ---
 # [START servicemesh_deployment_manifests_accounts_db_destinationrule_accounts_db_destination]
@@ -124,8 +124,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-5-2
+  - name: v0-5-3
     labels:
-      version: v0.5.2
+      version: v0.5.3
 # [END servicemesh_deployment_manifests_accounts_db_destinationrule_accounts_db_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/accounts-db.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/accounts-db.yaml
@@ -33,7 +33,7 @@ spec:
       labels:
         app: accounts-db
         tier: db
-        version: v0.2.0
+        version: v0.5.2
     spec:
       serviceAccountName: default
       containers:
@@ -110,7 +110,7 @@ spec:
   - route:
     - destination:
         host: accounts-db
-        subset: v0-2-0
+        subset: v0-5-2
 # [END servicemesh_deployment_manifests_accounts_db_virtualservice_accounts_db]
 ---
 # [START servicemesh_deployment_manifests_accounts_db_destinationrule_accounts_db_destination]
@@ -124,8 +124,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-2-0
+  - name: v0-5-2
     labels:
-      version: v0.2.0
+      version: v0.5.2
 # [END servicemesh_deployment_manifests_accounts_db_destinationrule_accounts_db_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/accounts-db.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/accounts-db.yaml
@@ -22,7 +22,7 @@ metadata:
     app: accounts-db
     tier: db
 spec:
-  serviceName: accounts-db
+  serviceName: "accounts-db"
   replicas: 1
   selector:
     matchLabels:
@@ -35,19 +35,20 @@ spec:
         tier: db
         version: v0.2.0
     spec:
+      serviceAccountName: default
       containers:
       - name: accounts-db
-        image: gcr.io/bank-of-anthos/accounts-db:latest
+        image: gcr.io/bank-of-anthos-ci/accounts-db:latest
         envFrom:
-        - configMapRef:
-            name: environment-config
-        - configMapRef:
-            name: accounts-db-config
-        - configMapRef:
-            name: default-data-config
+          - configMapRef:
+              name: environment-config
+          - configMapRef:
+              name: accounts-db-config
+          - configMapRef:
+              name: demo-data-config
         ports:
-        - containerPort: 5432
-          name: postgredb
+          - containerPort: 5432
+            name: postgredb
         resources:
           requests:
             cpu: 100m
@@ -74,10 +75,10 @@ metadata:
     tier: db
 spec:
   ports:
-  - port: 5432
-    name: tcp-postgredb
-    targetPort: 5432
-    protocol: TCP
+    - port: 5432
+      name: tcp
+      targetPort: 5432
+      protocol: TCP
   selector:
     app: accounts-db
     tier: db

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/accounts-db.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/accounts-db.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: accounts-db
-        image: gcr.io/bank-of-anthos-ci/accounts-db:latest
+        image: gcr.io/bank-of-anthos-ci/accounts-db:v0.5.2
         envFrom:
           - configMapRef:
               name: environment-config

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/balance-reader.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/balance-reader.yaml
@@ -26,20 +26,20 @@ spec:
     metadata:
       labels:
         app: balancereader
-        version: v0.5.2
+        version: v0.5.3
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
       - name: balancereader
-        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.3
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.2"
+          value: "v0.5.3"
         - name: PORT
           value: "8080"
         # toggle Cloud Trace export
@@ -125,7 +125,7 @@ spec:
   - route:
     - destination:
         host: balancereader
-        subset: v0-5-2
+        subset: v0-5-3
 # [END servicemesh_deployment_manifests_balance_reader_virtualservice_balancereader]
 ---
 # [START servicemesh_deployment_manifests_balance_reader_destinationrule_balancereader_destination]
@@ -139,8 +139,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-5-2
+  - name: v0-5-3
     labels:
-      version: v0.5.2
+      version: v0.5.3
 # [END servicemesh_deployment_manifests_balance_reader_destinationrule_balancereader_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/balance-reader.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/balance-reader.yaml
@@ -28,26 +28,40 @@ spec:
         app: balancereader
         version: v0.2.0
     spec:
+      serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
-      - name: reader
-        image: gcr.io/bank-of-anthos/balancereader:latest
+      - name: balancereader
+        image: gcr.io/bank-of-anthos-ci/balancereader:latest
         volumeMounts:
         - name: publickey
-          mountPath: /root/.ssh
+          mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: v0.2.0
+          value: "v0.5.2"
         - name: PORT
-          value: '8080'
+          value: "8080"
+        # toggle Cloud Trace export
+        - name: ENABLE_TRACING
+          value: "true"
+        - name: ENABLE_METRICS
+          value: "true"
         - name: POLL_MS
-          value: '100'
+          value: "100"
         - name: CACHE_SIZE
-          value: '1000000'
+          value: "1000000"
         # tell Java to obey container memory limits
         - name: JVM_OPTS
-          value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+        # Valid levels are debug, info, warn, error, fatal.
+        # If no valid level is set, will default to info.
+        - name: LOG_LEVEL
+          value: "info"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         envFrom:
         - configMapRef:
             name: environment-config
@@ -65,14 +79,16 @@ spec:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 60
           periodSeconds: 5
+          timeoutSeconds: 10
         livenessProbe:
           httpGet:
             path: /healthy
             port: 8080
           initialDelaySeconds: 120
           periodSeconds: 5
+          timeoutSeconds: 10
       volumes:
       - name: publickey
         secret:

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/balance-reader.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/balance-reader.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: balancereader
-        image: gcr.io/bank-of-anthos-ci/balancereader:latest
+        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/balance-reader.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/balance-reader.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       labels:
         app: balancereader
-        version: v0.2.0
+        version: v0.5.2
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -125,7 +125,7 @@ spec:
   - route:
     - destination:
         host: balancereader
-        subset: v0-2-0
+        subset: v0-5-2
 # [END servicemesh_deployment_manifests_balance_reader_virtualservice_balancereader]
 ---
 # [START servicemesh_deployment_manifests_balance_reader_destinationrule_balancereader_destination]
@@ -139,8 +139,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-2-0
+  - name: v0-5-2
     labels:
-      version: v0.2.0
+      version: v0.5.2
 # [END servicemesh_deployment_manifests_balance_reader_destinationrule_balancereader_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/config.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/config.yaml
@@ -19,8 +19,8 @@ kind: ConfigMap
 metadata:
   name: environment-config
 data:
-  LOCAL_ROUTING_NUM: '123456789'
-  PUB_KEY_PATH: /root/.ssh/publickey
+  LOCAL_ROUTING_NUM: "883745000"
+  PUB_KEY_PATH: "/root/.ssh/publickey"
 # [END servicemesh_deployment_manifests_config_configmap_environment_config]
 ---
 # [START servicemesh_deployment_manifests_config_configmap_service_api_config]
@@ -29,31 +29,22 @@ kind: ConfigMap
 metadata:
   name: service-api-config
 data:
-  TRANSACTIONS_API_ADDR: ledgerwriter:8080
-  BALANCES_API_ADDR: balancereader:8080
-  HISTORY_API_ADDR: transactionhistory:8080
-  CONTACTS_API_ADDR: contacts:8080
-  USERSERVICE_API_ADDR: userservice:8080
+  TRANSACTIONS_API_ADDR: "ledgerwriter:8080"
+  BALANCES_API_ADDR: "balancereader:8080"
+  HISTORY_API_ADDR: "transactionhistory:8080"
+  CONTACTS_API_ADDR: "contacts:8080"
+  USERSERVICE_API_ADDR: "userservice:8080"
 # [END servicemesh_deployment_manifests_config_configmap_service_api_config]
 ---
 # [START servicemesh_deployment_manifests_config_configmap_default_data_config]
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: default-data-config
+  name: demo-data-config
 data:
-  # All default user accounts are hardcoded to use the login password 'password'
-  USE_DEFAULT_DATA: 'True'
-  DEFAULT_LOGIN_PASSWORD: password
-  DEFAULT_USER_ACCOUNT: '1033623433'
-  DEFAULT_USER_USERNAME: testuser
-  DEFAULT_USER_NAME: Eve
-  DEFAULT_DEPOSIT_ACCOUNT: '9099791699'
-  DEFAULT_DEPOSIT_ROUTING: '808889588'
-  DEFAULT_DEPOSIT_LABEL: External Bank
-  DEFAULT_CONTACT_ACCOUNT_A: '1044226144'
-  DEFAULT_CONTACT_NAME_A: Alice
-  DEFAULT_CONTACT_ACCOUNT_B: '1055757655'
-  DEFAULT_CONTACT_NAME_B: Bob
+  USE_DEMO_DATA: "True"
+  DEMO_LOGIN_USERNAME: "testuser"
+  # All demo user accounts are hardcoded to use the login password 'password'
+  DEMO_LOGIN_PASSWORD: "password"
 # [END servicemesh_deployment_manifests_config_configmap_default_data_config]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/contacts.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/contacts.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       labels:
         app: contacts
-        version: v0.2.0
+        version: v0.5.2
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -103,7 +103,7 @@ spec:
   - route:
     - destination:
         host: contacts
-        subset: v0-2-0
+        subset: v0-5-2
 # [END servicemesh_deployment_manifests_contacts_virtualservice_contacts]
 ---
 # [START servicemesh_deployment_manifests_contacts_destinationrule_contacts_destination]
@@ -117,8 +117,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-2-0
+  - name: v0-5-2
     labels:
-      version: v0.2.0
+      version: v0.5.2
 # [END servicemesh_deployment_manifests_contacts_destinationrule_contacts_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/contacts.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/contacts.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos-ci/contacts:latest
+        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/contacts.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/contacts.yaml
@@ -28,19 +28,26 @@ spec:
         app: contacts
         version: v0.2.0
     spec:
+      serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos/contacts:latest
+        image: gcr.io/bank-of-anthos-ci/contacts:latest
         volumeMounts:
         - name: publickey
-          mountPath: /root/.ssh
+          mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: v0.2.0
+          value: "v0.5.2"
         - name: PORT
-          value: '8080'
+          value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
+        # Valid levels are debug, info, warning, error, critical.
+        # If no valid level is set, will default to info.
+        - name: LOG_LEVEL
+          value: "info"
         envFrom:
         - configMapRef:
             name: environment-config
@@ -57,8 +64,9 @@ spec:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
+          timeoutSeconds: 10
       volumes:
       - name: publickey
         secret:

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/contacts.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/contacts.yaml
@@ -26,20 +26,20 @@ spec:
     metadata:
       labels:
         app: contacts
-        version: v0.5.2
+        version: v0.5.3
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.3
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.2"
+          value: "v0.5.3"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
@@ -103,7 +103,7 @@ spec:
   - route:
     - destination:
         host: contacts
-        subset: v0-5-2
+        subset: v0-5-3
 # [END servicemesh_deployment_manifests_contacts_virtualservice_contacts]
 ---
 # [START servicemesh_deployment_manifests_contacts_destinationrule_contacts_destination]
@@ -117,8 +117,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-5-2
+  - name: v0-5-3
     labels:
-      version: v0.5.2
+      version: v0.5.3
 # [END servicemesh_deployment_manifests_contacts_destinationrule_contacts_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/frontend.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/frontend.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       labels:
         app: frontend
-        version: v0.2.0
+        version: v0.5.2
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -132,7 +132,7 @@ spec:
     route:
     - destination:
         host: frontend
-        subset: v0-2-0
+        subset: v0-5-2
 # [END servicemesh_deployment_manifests_frontend_virtualservice_frontend]
 ---
 # [START servicemesh_deployment_manifests_frontend_destinationrule_frontend_destination]
@@ -146,8 +146,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-2-0
+  - name: v0-5-2
     labels:
-      version: v0.2.0
+      version: v0.5.2
 # [END servicemesh_deployment_manifests_frontend_destinationrule_frontend_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/frontend.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/frontend.yaml
@@ -26,20 +26,20 @@ spec:
     metadata:
       labels:
         app: frontend
-        version: v0.5.2
+        version: v0.5.3
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.3
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.2"
+          value: "v0.5.3"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
@@ -132,7 +132,7 @@ spec:
     route:
     - destination:
         host: frontend
-        subset: v0-5-2
+        subset: v0-5-3
 # [END servicemesh_deployment_manifests_frontend_virtualservice_frontend]
 ---
 # [START servicemesh_deployment_manifests_frontend_destinationrule_frontend_destination]
@@ -146,8 +146,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-5-2
+  - name: v0-5-3
     labels:
-      version: v0.5.2
+      version: v0.5.3
 # [END servicemesh_deployment_manifests_frontend_destinationrule_frontend_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/frontend.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/frontend.yaml
@@ -28,29 +28,43 @@ spec:
         app: frontend
         version: v0.2.0
     spec:
+      serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos/frontend:latest
+        image: gcr.io/bank-of-anthos-ci/frontend:latest
         volumeMounts:
         - name: publickey
-          mountPath: /root/.ssh
+          mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: v0.2.0
+          value: "v0.5.2"
         - name: PORT
-          value: '8080'
+          value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
+        - name: SCHEME
+          value: "http"
+         # Valid levels are debug, info, warning, error, critical. If no valid level is set, gunicorn will default to info.
+        - name: LOG_LEVEL
+          value: "info"
+        # Set to "true" to enable the CymbalBank logo + title
+        # - name: CYMBAL_LOGO
+        #   value: "false"
+        # Customize the bank name used in the header. Defaults to 'Bank of Anthos' - when CYMBAL_LOGO is true, uses 'CymbalBank'
+        # - name: BANK_NAME
+        #   value: ""
         - name: DEFAULT_USERNAME
           valueFrom:
             configMapKeyRef:
-              name: default-data-config
-              key: DEFAULT_USER_USERNAME
+              name: demo-data-config
+              key: DEMO_LOGIN_USERNAME
         - name: DEFAULT_PASSWORD
           valueFrom:
             configMapKeyRef:
-              name: default-data-config
-              key: DEFAULT_LOGIN_PASSWORD
+              name: demo-data-config
+              key: DEMO_LOGIN_PASSWORD
         envFrom:
         - configMapRef:
             name: environment-config
@@ -60,8 +74,16 @@ spec:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 30
         resources:
           requests:
             cpu: 100m

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/frontend.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/frontend.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos-ci/frontend:latest
+        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-db.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-db.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       labels:
         app: ledger-db
-        version: v0.2.0
+        version: v0.5.2
     spec:
       serviceAccountName: default
       containers:
@@ -102,7 +102,7 @@ spec:
   - route:
     - destination:
         host: ledger-db
-        subset: v0-2-0
+        subset: v0-5-2
 # [END servicemesh_deployment_manifests_ledger_db_virtualservice_ledger_db]
 ---
 # [START servicemesh_deployment_manifests_ledger_db_destinationrule_ledger_db_destination]
@@ -116,8 +116,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-2-0
+  - name: v0-5-2
     labels:
-      version: v0.2.0
+      version: v0.5.2
 # [END servicemesh_deployment_manifests_ledger_db_destinationrule_ledger_db_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-db.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-db.yaml
@@ -19,7 +19,7 @@ apiVersion: apps/v1
 metadata:
   name: ledger-db
 spec:
-  serviceName: ledger-db
+  serviceName: "ledger-db"
   replicas: 1
   selector:
     matchLabels:
@@ -30,32 +30,33 @@ spec:
         app: ledger-db
         version: v0.2.0
     spec:
+      serviceAccountName: default
       containers:
-      - name: postgres
-        image: gcr.io/bank-of-anthos/ledger-db:latest
-        ports:
-        - containerPort: 5432
-        envFrom:
-        - configMapRef:
-            name: environment-config
-        - configMapRef:
-            name: ledger-db-config
-        - configMapRef:
-            name: default-data-config
-        resources:
-          requests:
-            cpu: 100m
-            memory: 512Mi
-          limits:
-            cpu: 500m
-            memory: 1Gi
-        volumeMounts:
-        - name: postgresdb
-          mountPath: /var/lib/postgresql/data
-          subPath: postgres
+        - name: postgres
+          image: gcr.io/bank-of-anthos-ci/ledger-db:latest
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - configMapRef:
+                name: environment-config
+            - configMapRef:
+                name: ledger-db-config
+            - configMapRef:
+                name: demo-data-config
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: postgresdb
+              mountPath: /var/lib/postgresql/data
+              subPath: postgres
       volumes:
-      - name: postgresdb
-        emptyDir: {}
+        - name: postgresdb
+          emptyDir: {}
 # [END servicemesh_deployment_manifests_ledger_db_statefulset_ledger_db]
 ---
 # [START servicemesh_deployment_manifests_ledger_db_configmap_ledger_db_config]
@@ -67,7 +68,7 @@ metadata:
     app: postgres
 data:
   POSTGRES_DB: postgresdb
-  POSTGRES_USER: admin 
+  POSTGRES_USER: admin
   POSTGRES_PASSWORD: password
   SPRING_DATASOURCE_URL: jdbc:postgresql://ledger-db:5432/postgresdb
   SPRING_DATASOURCE_USERNAME: admin # should match POSTGRES_USER
@@ -84,7 +85,7 @@ spec:
   selector:
     app: ledger-db
   ports:
-  - name: tcp-postgres
+  - name: tcp
     port: 5432
     targetPort: 5432
 # [END servicemesh_deployment_manifests_ledger_db_service_ledger_db]

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-db.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-db.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: postgres
-          image: gcr.io/bank-of-anthos-ci/ledger-db:latest
+          image: gcr.io/bank-of-anthos-ci/ledger-db:v0.5.2
           ports:
             - containerPort: 5432
           envFrom:

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-db.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-db.yaml
@@ -28,12 +28,12 @@ spec:
     metadata:
       labels:
         app: ledger-db
-        version: v0.5.2
+        version: v0.5.3
     spec:
       serviceAccountName: default
       containers:
         - name: postgres
-          image: gcr.io/bank-of-anthos-ci/ledger-db:v0.5.2
+          image: gcr.io/bank-of-anthos-ci/ledger-db:v0.5.3
           ports:
             - containerPort: 5432
           envFrom:
@@ -102,7 +102,7 @@ spec:
   - route:
     - destination:
         host: ledger-db
-        subset: v0-5-2
+        subset: v0-5-3
 # [END servicemesh_deployment_manifests_ledger_db_virtualservice_ledger_db]
 ---
 # [START servicemesh_deployment_manifests_ledger_db_destinationrule_ledger_db_destination]
@@ -116,8 +116,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-5-2
+  - name: v0-5-3
     labels:
-      version: v0.5.2
+      version: v0.5.3
 # [END servicemesh_deployment_manifests_ledger_db_destinationrule_ledger_db_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-writer.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-writer.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       labels:
         app: ledgerwriter
-        version: v0.2.0
+        version: v0.5.2
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -114,7 +114,7 @@ spec:
   - route:
     - destination:
         host: ledgerwriter
-        subset: v0-2-0
+        subset: v0-5-2
 # [END servicemesh_deployment_manifests_ledger_writer_virtualservice_ledgerwriter]
 ---
 # [START servicemesh_deployment_manifests_ledger_writer_destinationrule_ledgerwriter_destination]
@@ -128,8 +128,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-2-0
+  - name: v0-5-2
     labels:
-      version: v0.2.0
+      version: v0.5.2
 # [END servicemesh_deployment_manifests_ledger_writer_destinationrule_ledgerwriter_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-writer.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-writer.yaml
@@ -28,22 +28,34 @@ spec:
         app: ledgerwriter
         version: v0.2.0
     spec:
+      serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
-      - name: writer
-        image: gcr.io/bank-of-anthos/ledgerwriter:latest
+      - name: ledgerwriter
+        image: gcr.io/bank-of-anthos-ci/ledgerwriter:latest
         volumeMounts:
         - name: publickey
-          mountPath: /root/.ssh
+          mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: v0.2.0
+          value: "v0.5.2"
         - name: PORT
-          value: '8080'
+          value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
+        - name: ENABLE_METRICS
+          value: "true"
          # tell Java to obey container memory limits
         - name: JVM_OPTS
-          value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+        # service level override of log level
+        - name: LOG_LEVEL
+          value: "info"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         envFrom:
         - configMapRef:
             name: environment-config
@@ -63,8 +75,9 @@ spec:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 60
           periodSeconds: 5
+          timeoutSeconds: 10
       volumes:
       - name: publickey
         secret:

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-writer.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-writer.yaml
@@ -26,20 +26,20 @@ spec:
     metadata:
       labels:
         app: ledgerwriter
-        version: v0.5.2
+        version: v0.5.3
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
       - name: ledgerwriter
-        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.3
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.2"
+          value: "v0.5.3"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
@@ -114,7 +114,7 @@ spec:
   - route:
     - destination:
         host: ledgerwriter
-        subset: v0-5-2
+        subset: v0-5-3
 # [END servicemesh_deployment_manifests_ledger_writer_virtualservice_ledgerwriter]
 ---
 # [START servicemesh_deployment_manifests_ledger_writer_destinationrule_ledgerwriter_destination]
@@ -128,8 +128,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-5-2
+  - name: v0-5-3
     labels:
-      version: v0.5.2
+      version: v0.5.3
 # [END servicemesh_deployment_manifests_ledger_writer_destinationrule_ledgerwriter_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-writer.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/ledger-writer.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: ledgerwriter
-        image: gcr.io/bank-of-anthos-ci/ledgerwriter:latest
+        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/loadgenerator.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/loadgenerator.yaml
@@ -28,18 +28,21 @@ spec:
       labels:
         app: loadgenerator
       annotations:
-        sidecar.istio.io/rewriteAppHTTPProbers: 'true'
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
+      serviceAccountName: default
       terminationGracePeriodSeconds: 5
       restartPolicy: Always
       containers:
-      - name: main
-        image: gcr.io/bank-of-anthos/loadgenerator:latest
+      - name: loadgenerator
+        image: gcr.io/bank-of-anthos-ci/loadgenerator:latest
         env:
         - name: FRONTEND_ADDR
-          value: frontend:80
+          value: "frontend:80"
         - name: USERS
-          value: '5'
+          value: "5"
+        - name: LOG_LEVEL
+          value: "error"
         resources:
           requests:
             cpu: 100m

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/loadgenerator.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/loadgenerator.yaml
@@ -35,7 +35,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: loadgenerator
-        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.3
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/loadgenerator.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/loadgenerator.yaml
@@ -35,7 +35,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: loadgenerator
-        image: gcr.io/bank-of-anthos-ci/loadgenerator:latest
+        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.2
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/transaction-history.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/transaction-history.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: transactionhistory
-        image: gcr.io/bank-of-anthos-ci/transactionhistory:latest
+        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/transaction-history.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/transaction-history.yaml
@@ -26,20 +26,20 @@ spec:
     metadata:
       labels:
         app: transactionhistory
-        version: v0.5.2
+        version: v0.5.3
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
       - name: transactionhistory
-        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.3
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.2"
+          value: "v0.5.3"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
@@ -130,7 +130,7 @@ spec:
   - route:
     - destination:
         host: transactionhistory
-        subset: v0-5-2
+        subset: v0-5-3
 # [END servicemesh_deployment_manifests_transaction_history_virtualservice_transactionhistory]
 ---
 # [START servicemesh_deployment_manifests_transaction_history_destinationrule_transactionhistory_destination]
@@ -144,8 +144,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-5-2
+  - name: v0-5-3
     labels:
-      version: v0.5.2
+      version: v0.5.3
 # [END servicemesh_deployment_manifests_transaction_history_destinationrule_transactionhistory_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/transaction-history.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/transaction-history.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       labels:
         app: transactionhistory
-        version: v0.2.0
+        version: v0.5.2
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -130,7 +130,7 @@ spec:
   - route:
     - destination:
         host: transactionhistory
-        subset: v0-2-0
+        subset: v0-5-2
 # [END servicemesh_deployment_manifests_transaction_history_virtualservice_transactionhistory]
 ---
 # [START servicemesh_deployment_manifests_transaction_history_destinationrule_transactionhistory_destination]
@@ -144,8 +144,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-2-0
+  - name: v0-5-2
     labels:
-      version: v0.2.0
+      version: v0.5.2
 # [END servicemesh_deployment_manifests_transaction_history_destinationrule_transactionhistory_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/transaction-history.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/transaction-history.yaml
@@ -28,32 +28,45 @@ spec:
         app: transactionhistory
         version: v0.2.0
     spec:
+      serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
-      - name: history
-        image: gcr.io/bank-of-anthos/transactionhistory:latest
+      - name: transactionhistory
+        image: gcr.io/bank-of-anthos-ci/transactionhistory:latest
         volumeMounts:
         - name: publickey
-          mountPath: /root/.ssh
+          mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: v0.2.0
+          value: "v0.5.2"
         - name: PORT
-          value: '8080'
+          value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
+        - name: ENABLE_METRICS
+          value: "true"
         - name: POLL_MS
-          value: '100'
+          value: "100"
         - name: CACHE_SIZE
-          value: '1000'
+          value: "1000"
         - name: CACHE_MINUTES
-          value: '60'
+          value: "60"
         - name: HISTORY_LIMIT
-          value: '100'
+          value: "100"
           # tell Java to obey container memory limits
         - name: JVM_OPTS
-          value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
         #- name: EXTRA_LATENCY_MILLIS
         #  value: "5000"
+        # Valid levels are debug, info, warn, error, fatal.
+        # If no valid level is set, will default to info.
+        - name: LOG_LEVEL
+          value: "info"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         envFrom:
         - configMapRef:
             name: environment-config
@@ -71,14 +84,16 @@ spec:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 60
           periodSeconds: 5
+          timeoutSeconds: 10
         livenessProbe:
           httpGet:
             path: /healthy
             port: 8080
           initialDelaySeconds: 120
           periodSeconds: 5
+          timeoutSeconds: 10
       volumes:
       - name: publickey
         secret:

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/userservice.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/userservice.yaml
@@ -28,26 +28,32 @@ spec:
         app: userservice
         version: v0.2.0
     spec:
+      serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos/userservice:latest
+        image: gcr.io/bank-of-anthos-ci/userservice:latest
         volumeMounts:
         - name: keys
-          mountPath: /root/.ssh
+          mountPath: "/root/.ssh"
           readOnly: true
         ports:
         - name: http-server
           containerPort: 8080
         env:
         - name: VERSION
-          value: v0.2.0
+          value: "v0.5.2"
         - name: PORT
-          value: '8080'
+          value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
         - name: TOKEN_EXPIRY_SECONDS
-          value: '3600'
+          value: "3600"
         - name: PRIV_KEY_PATH
-          value: /root/.ssh/privatekey
+          value: "/root/.ssh/privatekey"
+        # Valid levels are debug, info, warning, error, critical. If no valid level is set, gunicorn will default to info.
+        - name: LOG_LEVEL
+          value: "info"
         envFrom:
         - configMapRef:
             name: environment-config
@@ -57,8 +63,9 @@ spec:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 100m

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/userservice.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/userservice.yaml
@@ -26,13 +26,13 @@ spec:
     metadata:
       labels:
         app: userservice
-        version: v0.5.2
+        version: v0.5.3
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.3
         volumeMounts:
         - name: keys
           mountPath: "/root/.ssh"
@@ -42,7 +42,7 @@ spec:
           containerPort: 8080
         env:
         - name: VERSION
-          value: "v0.5.2"
+          value: "v0.5.3"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
@@ -111,7 +111,7 @@ spec:
   - route:
     - destination:
         host: userservice
-        subset: v0-5-2
+        subset: v0-5-3
 # [END servicemesh_deployment_manifests_userservice_virtualservice_userservice]
 ---
 # [START servicemesh_deployment_manifests_userservice_destinationrule_userservice_destination]
@@ -125,8 +125,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-5-2
+  - name: v0-5-3
     labels:
-      version: v0.5.2
+      version: v0.5.3
 # [END servicemesh_deployment_manifests_userservice_destinationrule_userservice_destination]
 ---

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/userservice.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/userservice.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos-ci/userservice:latest
+        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.2
         volumeMounts:
         - name: keys
           mountPath: "/root/.ssh"

--- a/demos/bank-of-anthos-asm-manifests/deployment-manifests/userservice.yaml
+++ b/demos/bank-of-anthos-asm-manifests/deployment-manifests/userservice.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       labels:
         app: userservice
-        version: v0.2.0
+        version: v0.5.2
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -111,7 +111,7 @@ spec:
   - route:
     - destination:
         host: userservice
-        subset: v0-2-0
+        subset: v0-5-2
 # [END servicemesh_deployment_manifests_userservice_virtualservice_userservice]
 ---
 # [START servicemesh_deployment_manifests_userservice_destinationrule_userservice_destination]
@@ -125,8 +125,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
   subsets:
-  - name: v0-2-0
+  - name: v0-5-2
     labels:
-      version: v0.2.0
+      version: v0.5.2
 # [END servicemesh_deployment_manifests_userservice_destinationrule_userservice_destination]
 ---


### PR DESCRIPTION
Update this repo with latest BankofAnthos version https://github.com/GoogleCloudPlatform/bank-of-anthos/releases/tag/v0.5.3.

Kubernetes manifests have been updated from this folder: https://github.com/GoogleCloudPlatform/bank-of-anthos/tree/release/v0.5.3/kubernetes-manifests

Remarks:
- [x] To avoid any issue in the future and a de-synchronization between manifests and image tag, we are changing the image tag from `latest` to `v0.5.3`.
- [X] In `Deployment` the value `v0.2.0` of the `spec.template.metadata.labels.version` seems to refer to the boa release tag. It's used by the `DestinationRule`'s `spec.subsets[0].labels.version` field. So we are changing that label to the boa tag `0.5.3` too.
- [X] Reached out to Googler contributors of this repo: @benjamin-maynard is not using this repo anymore. @jeremysolarz is not leveraging that part in the mtls-egress-ingress part of this same repo.
- [X] Test the deployment of those manifests on a GKE cluster (see snippet of the tests in the comment on this PR)
- [X] Fixes https://github.com/GoogleCloudPlatform/anthos-service-mesh-samples/issues/37
- [X] Fixes https://github.com/GoogleCloudPlatform/anthos-service-mesh-samples/issues/40