### PR TITLE
Added region tags to ACM/ASM tutorial

### DIFF
--- a/docs/asm-installation-manifests/base/controlplane-configs.yaml
+++ b/docs/asm-installation-manifests/base/controlplane-configs.yaml
@@ -1,3 +1,4 @@
+
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_base_controlplane_configs_controlplanerevision_asm_managed]
 apiVersion: mesh.cloud.google.com/v1beta1
 kind: ControlPlaneRevision
 metadata:
   name: asm-managed
   labels:
-    mesh.cloud.google.com/managed-cni-enabled: "true"
+    mesh.cloud.google.com/managed-cni-enabled: 'true'
 spec:
   type: managed_service
   channel: regular
+# [END servicemesh_base_controlplane_configs_controlplanerevision_asm_managed]

--- a/docs/asm-installation-manifests/base/controlplane-configs.yaml
+++ b/docs/asm-installation-manifests/base/controlplane-configs.yaml
@@ -1,4 +1,3 @@
-
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +18,7 @@ kind: ControlPlaneRevision
 metadata:
   name: asm-managed
   labels:
-    mesh.cloud.google.com/managed-cni-enabled: 'true'
+    mesh.cloud.google.com/managed-cni-enabled: "true"
 spec:
   type: managed_service
   channel: regular

--- a/docs/asm-installation-manifests/base/kustomization.yaml
+++ b/docs/asm-installation-manifests/base/kustomization.yaml
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_asm_installation_manifests_base_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - namespace.yaml
 - controlplane-configs.yaml
+# [END servicemesh_asm_installation_manifests_base_kustomization_kustomization]

--- a/docs/asm-installation-manifests/base/namespace.yaml
+++ b/docs/asm-installation-manifests/base/namespace.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_base_namespace_namespace_istio_system]
 apiVersion: v1
 kind: Namespace
 metadata:
   name: istio-system
+# [END servicemesh_base_namespace_namespace_istio_system]

--- a/docs/asm-installation-manifests/for-asm-channel/kustomization.yaml
+++ b/docs/asm-installation-manifests/for-asm-channel/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_asm_installation_manifests_for_asm_channel_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patchesJson6902:
@@ -25,3 +26,4 @@ patchesJson6902:
     - op: replace
       path: /spec/channel
       value: ASM_CHANNEL
+# [END servicemesh_asm_installation_manifests_for_asm_channel_kustomization_component]

--- a/docs/asm-installation-manifests/kustomization.yaml
+++ b/docs/asm-installation-manifests/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_docs_asm_installation_manifests_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: istio-system
@@ -19,3 +20,4 @@ resources:
 - base
 components:
 - for-asm-channel
+# [END servicemesh_docs_asm_installation_manifests_kustomization_kustomization]

--- a/docs/asm-installation-manifests/with-default-deny-authorization-policy/authorizationpolicy.yaml
+++ b/docs/asm-installation-manifests/with-default-deny-authorization-policy/authorizationpolicy.yaml
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_with_default_deny_authorization_policy_authorizationpolicy_authorizationpolicy_deny_all]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: deny-all
 spec:
   {}
+# [END servicemesh_with_default_deny_authorization_policy_authorizationpolicy_authorizationpolicy_deny_all]

--- a/docs/asm-installation-manifests/with-default-deny-authorization-policy/kustomization.yaml
+++ b/docs/asm-installation-manifests/with-default-deny-authorization-policy/kustomization.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_asm_installation_manifests_with_default_deny_authorization_policy_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - authorizationpolicy.yaml
+# [END servicemesh_asm_installation_manifests_with_default_deny_authorization_policy_kustomization_kustomization]

--- a/docs/asm-installation-manifests/with-strict-mtls/kustomization.yaml
+++ b/docs/asm-installation-manifests/with-strict-mtls/kustomization.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_asm_installation_manifests_with_strict_mtls_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - peerauthentication.yaml
+# [END servicemesh_asm_installation_manifests_with_strict_mtls_kustomization_kustomization]

--- a/docs/asm-installation-manifests/with-strict-mtls/peerauthentication.yaml
+++ b/docs/asm-installation-manifests/with-strict-mtls/peerauthentication.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_with_strict_mtls_peerauthentication_peerauthentication_default]
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
@@ -19,3 +20,4 @@ metadata:
 spec:
   mtls:
     mode: STRICT
+# [END servicemesh_with_strict_mtls_peerauthentication_peerauthentication_default]

--- a/docs/ingress-gateway-asm-manifests/base/deployment.yaml
+++ b/docs/ingress-gateway-asm-manifests/base/deployment.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_base_deployment_deployment_asm_ingressgateway]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -56,3 +57,4 @@ spec:
         runAsNonRoot: true
         runAsUser: 1337
       serviceAccountName: asm-ingressgateway
+# [END servicemesh_base_deployment_deployment_asm_ingressgateway]

--- a/docs/ingress-gateway-asm-manifests/base/gateway.yaml
+++ b/docs/ingress-gateway-asm-manifests/base/gateway.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_base_gateway_gateway_asm_ingressgateway]
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -26,3 +27,4 @@ spec:
         protocol: HTTP
       hosts:
         - "*"
+# [END servicemesh_base_gateway_gateway_asm_ingressgateway]

--- a/docs/ingress-gateway-asm-manifests/base/kustomization.yaml
+++ b/docs/ingress-gateway-asm-manifests/base/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_ingress_gateway_asm_manifests_base_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -20,3 +21,4 @@ resources:
 - namespace.yaml
 - service.yaml
 - serviceaccount.yaml
+# [END servicemesh_ingress_gateway_asm_manifests_base_kustomization_kustomization]

--- a/docs/ingress-gateway-asm-manifests/base/namespace.yaml
+++ b/docs/ingress-gateway-asm-manifests/base/namespace.yaml
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_base_namespace_namespace_asm_ingress]
 apiVersion: v1
 kind: Namespace
 metadata:
   name: asm-ingress
   labels:
     istio.io/rev: asm-managed
+# [END servicemesh_base_namespace_namespace_asm_ingress]

--- a/docs/ingress-gateway-asm-manifests/base/service.yaml
+++ b/docs/ingress-gateway-asm-manifests/base/service.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_base_service_service_asm_ingressgateway]
 apiVersion: v1
 kind: Service
 metadata:
@@ -26,3 +27,4 @@ spec:
   selector:
     asm: ingressgateway
   type: LoadBalancer
+# [END servicemesh_base_service_service_asm_ingressgateway]

--- a/docs/ingress-gateway-asm-manifests/base/serviceaccount.yaml
+++ b/docs/ingress-gateway-asm-manifests/base/serviceaccount.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_base_serviceaccount_serviceaccount_asm_ingressgateway]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: asm-ingressgateway
+# [END servicemesh_base_serviceaccount_serviceaccount_asm_ingressgateway]

--- a/docs/ingress-gateway-asm-manifests/for-asm-channel/kustomization.yaml
+++ b/docs/ingress-gateway-asm-manifests/for-asm-channel/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_ingress_gateway_asm_manifests_for_asm_channel_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patches:
@@ -22,3 +23,4 @@ patches:
         name: asm-ingress
         labels:
           istio.io/rev: ASM_VERSION
+# [END servicemesh_ingress_gateway_asm_manifests_for_asm_channel_kustomization_component]

--- a/docs/ingress-gateway-asm-manifests/kustomization.yaml
+++ b/docs/ingress-gateway-asm-manifests/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_docs_ingress_gateway_asm_manifests_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: asm-ingress
@@ -20,3 +21,4 @@ resources:
 components:
 - for-asm-channel
 - with-authorization-policies
+# [END servicemesh_docs_ingress_gateway_asm_manifests_kustomization_kustomization]

--- a/docs/ingress-gateway-asm-manifests/with-authorization-policies/authorizationpolicy.yaml
+++ b/docs/ingress-gateway-asm-manifests/with-authorization-policies/authorizationpolicy.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_with_authorization_policies_authorizationpolicy_authorizationpolicy_asm_ingressgateway]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -25,3 +26,4 @@ spec:
     - operation:
         ports:
         - "8080"
+# [END servicemesh_with_authorization_policies_authorizationpolicy_authorizationpolicy_asm_ingressgateway]

--- a/docs/ingress-gateway-asm-manifests/with-authorization-policies/kustomization.yaml
+++ b/docs/ingress-gateway-asm-manifests/with-authorization-policies/kustomization.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_ingress_gateway_asm_manifests_with_authorization_policies_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
 - authorizationpolicy.yaml
+# [END servicemesh_ingress_gateway_asm_manifests_with_authorization_policies_kustomization_component]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-adservice.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-adservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_authorization_policy_adservice_authorizationpolicy_adservice]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -33,3 +34,4 @@ spec:
         - POST
         ports:
         - "9555"
+# [END servicemesh_all_authorization_policy_adservice_authorizationpolicy_adservice]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-cartservice.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-cartservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_authorization_policy_cartservice_authorizationpolicy_cartservice]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -36,3 +37,4 @@ spec:
         - POST
         ports:
         - "7070"
+# [END servicemesh_all_authorization_policy_cartservice_authorizationpolicy_cartservice]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-checkoutservice.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-checkoutservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_authorization_policy_checkoutservice_authorizationpolicy_checkoutservice]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -33,3 +34,4 @@ spec:
         - POST
         ports:
         - "5050"
+# [END servicemesh_all_authorization_policy_checkoutservice_authorizationpolicy_checkoutservice]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-currencyservice.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-currencyservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_authorization_policy_currencyservice_authorizationpolicy_currencyservice]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -35,3 +36,4 @@ spec:
         - POST
         ports:
         - "7000"
+# [END servicemesh_all_authorization_policy_currencyservice_authorizationpolicy_currencyservice]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-emailservice.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-emailservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_authorization_policy_emailservice_authorizationpolicy_emailservice]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -33,3 +34,4 @@ spec:
         - POST
         ports:
         - "8080"
+# [END servicemesh_all_authorization_policy_emailservice_authorizationpolicy_emailservice]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-frontend.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-frontend.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_authorization_policy_frontend_authorizationpolicy_frontend]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -32,3 +33,4 @@ spec:
         - POST
         ports:
         - "8080"
+# [END servicemesh_all_authorization_policy_frontend_authorizationpolicy_frontend]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-paymentservice.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-paymentservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_authorization_policy_paymentservice_authorizationpolicy_paymentservice]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -33,3 +34,4 @@ spec:
         - POST
         ports:
         - "50051"
+# [END servicemesh_all_authorization_policy_paymentservice_authorizationpolicy_paymentservice]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-productcatalogservice.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-productcatalogservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_authorization_policy_productcatalogservice_authorizationpolicy_productcatalogservice]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -36,3 +37,4 @@ spec:
         - POST
         ports:
         - "3550"
+# [END servicemesh_all_authorization_policy_productcatalogservice_authorizationpolicy_productcatalogservice]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-recommendationservice.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-recommendationservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_authorization_policy_recommendationservice_authorizationpolicy_recommendationservice]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -33,3 +34,4 @@ spec:
         - POST
         ports:
         - "8080"
+# [END servicemesh_all_authorization_policy_recommendationservice_authorizationpolicy_recommendationservice]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-redis.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-redis.yaml
@@ -29,5 +29,5 @@ spec:
     to:
     - operation:
         ports:
-        - '6379'
+        - "6379"
 # [END servicemesh_all_authorization_policy_redis_authorizationpolicy_redis_cart]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-redis.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-redis.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_authorization_policy_redis_authorizationpolicy_redis_cart]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -28,4 +29,5 @@ spec:
     to:
     - operation:
         ports:
-        - "6379"
+        - '6379'
+# [END servicemesh_all_authorization_policy_redis_authorizationpolicy_redis_cart]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-shippingservice.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/authorization-policy-shippingservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_authorization_policy_shippingservice_authorizationpolicy_shippingservice]
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -35,3 +36,4 @@ spec:
         - POST
         ports:
         - "50051"
+# [END servicemesh_all_authorization_policy_shippingservice_authorizationpolicy_shippingservice]

--- a/docs/online-boutique-asm-manifests/authorization-policies/all/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/all/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_authorization_policies_all_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
@@ -26,3 +27,4 @@ resources:
 - authorization-policy-recommendationservice.yaml
 - authorization-policy-redis.yaml
 - authorization-policy-shippingservice.yaml
+# [END servicemesh_authorization_policies_all_kustomization_component]

--- a/docs/online-boutique-asm-manifests/authorization-policies/for-ingress-gateway/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/for-ingress-gateway/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_authorization_policies_for_ingress_gateway_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patchesJson6902:
@@ -24,3 +25,4 @@ patchesJson6902:
       value:
         - cluster.local/ns/ONLINEBOUTIQUE_NAMESPACE/sa/loadgenerator
         - cluster.local/ns/INGRESS_GATEWAY_NAMESPACE/sa/INGRESS_GATEWAY_NAME
+# [END servicemesh_authorization_policies_for_ingress_gateway_kustomization_component]

--- a/docs/online-boutique-asm-manifests/authorization-policies/for-memorystore/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/for-memorystore/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_authorization_policies_for_memorystore_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patchesStrategicMerge:
@@ -21,3 +22,4 @@ patchesStrategicMerge:
   metadata:
     name: redis-cart
   $patch: delete
+# [END servicemesh_authorization_policies_for_memorystore_kustomization_component]

--- a/docs/online-boutique-asm-manifests/authorization-policies/for-namespace/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/for-namespace/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_authorization_policies_for_namespace_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patchesJson6902:
@@ -100,3 +101,4 @@ patchesJson6902:
       value:
         - cluster.local/ns/ONLINEBOUTIQUE_NAMESPACE/sa/frontend
         - cluster.local/ns/ONLINEBOUTIQUE_NAMESPACE/sa/checkoutservice
+# [END servicemesh_authorization_policies_for_namespace_kustomization_component]

--- a/docs/online-boutique-asm-manifests/authorization-policies/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/authorization-policies/kustomization.yaml
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_online_boutique_asm_manifests_authorization_policies_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:
 - all
 - for-ingress-gateway
 - for-namespace
+# [END servicemesh_online_boutique_asm_manifests_authorization_policies_kustomization_kustomization]

--- a/docs/online-boutique-asm-manifests/base/all/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/base/all/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_base_all_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -25,3 +26,4 @@ patchesStrategicMerge:
   metadata:
     name: frontend-external
   $patch: delete
+# [END servicemesh_base_all_kustomization_kustomization]

--- a/docs/online-boutique-asm-manifests/base/all/namespace.yaml
+++ b/docs/online-boutique-asm-manifests/base/all/namespace.yaml
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_namespace_namespace_onlineboutique]
 apiVersion: v1
 kind: Namespace
 metadata:
   name: onlineboutique
   labels:
     istio.io/rev: asm-managed
+# [END servicemesh_all_namespace_namespace_onlineboutique]

--- a/docs/online-boutique-asm-manifests/base/all/virtualservice.yaml
+++ b/docs/online-boutique-asm-manifests/base/all/virtualservice.yaml
@@ -20,7 +20,7 @@ metadata:
   name: frontend
 spec:
   hosts:
-  - '*'
+  - "*"
   gateways:
   - asm-ingress/asm-ingressgateway
   http:
@@ -30,4 +30,3 @@ spec:
         port:
           number: 80
 # [END servicemesh_all_virtualservice_virtualservice_frontend]
----

--- a/docs/online-boutique-asm-manifests/base/all/virtualservice.yaml
+++ b/docs/online-boutique-asm-manifests/base/all/virtualservice.yaml
@@ -1,3 +1,4 @@
+
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_virtualservice_virtualservice_frontend]
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: frontend
 spec:
   hosts:
-  - "*"
+  - '*'
   gateways:
   - asm-ingress/asm-ingressgateway
   http:
@@ -27,3 +29,5 @@ spec:
         host: frontend
         port:
           number: 80
+# [END servicemesh_all_virtualservice_virtualservice_frontend]
+---

--- a/docs/online-boutique-asm-manifests/base/for-asm-channel/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/base/for-asm-channel/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_base_for_asm_channel_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patches:
@@ -22,3 +23,4 @@ patches:
         name: onlineboutique
         labels:
           istio.io/rev: ASM_VERSION
+# [END servicemesh_base_for_asm_channel_kustomization_component]

--- a/docs/online-boutique-asm-manifests/base/for-memorystore/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/base/for-memorystore/kustomization.yaml
@@ -20,10 +20,23 @@ patchesJson6902:
 - target:
     kind: Deployment
     name: cartservice
-  patch: "- op: replace\n  path: /spec/template/spec/containers/0/env/0\n  value:\n\
-    \    name: REDIS_ADDR\n    value: REDIS_IP:REDIS_PORT"
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/env/0
+      value:
+        name: REDIS_ADDR
+        value: REDIS_IP:REDIS_PORT
 patchesStrategicMerge:
-- "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: redis-cart\n$patch: delete"
-- "apiVersion: v1\nkind: Service\nmetadata:\n  name: redis-cart\n$patch: delete"
+- |-
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: redis-cart
+  $patch: delete
+- |-
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: redis-cart
+  $patch: delete
 # [END servicemesh_base_for_memorystore_kustomization_component]
----

--- a/docs/online-boutique-asm-manifests/base/for-memorystore/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/base/for-memorystore/kustomization.yaml
@@ -1,3 +1,4 @@
+
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,28 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_base_for_memorystore_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patchesJson6902:
 - target:
     kind: Deployment
     name: cartservice
-  patch: |-
-    - op: replace
-      path: /spec/template/spec/containers/0/env/0
-      value:
-        name: REDIS_ADDR
-        value: REDIS_IP:REDIS_PORT
+  patch: "- op: replace\n  path: /spec/template/spec/containers/0/env/0\n  value:\n\
+    \    name: REDIS_ADDR\n    value: REDIS_IP:REDIS_PORT"
 patchesStrategicMerge:
-- |-
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: redis-cart
-  $patch: delete
-- |-
-  apiVersion: v1
-  kind: Service
-  metadata:
-    name: redis-cart
-  $patch: delete
+- "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: redis-cart\n$patch: delete"
+- "apiVersion: v1\nkind: Service\nmetadata:\n  name: redis-cart\n$patch: delete"
+# [END servicemesh_base_for_memorystore_kustomization_component]
+---

--- a/docs/online-boutique-asm-manifests/base/for-namespace/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/base/for-namespace/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_base_for_namespace_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patchesJson6902:
@@ -22,3 +23,4 @@ patchesJson6902:
     - op: replace
       path: /metadata/name
       value: ONLINEBOUTIQUE_NAMESPACE
+# [END servicemesh_base_for_namespace_kustomization_component]

--- a/docs/online-boutique-asm-manifests/base/for-virtualservice-host/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/base/for-virtualservice-host/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_base_for_virtualservice_host_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patchesJson6902:
@@ -23,3 +24,4 @@ patchesJson6902:
       path: /spec/hosts
       value:
         - HOST_NAME
+# [END servicemesh_base_for_virtualservice_host_kustomization_component]

--- a/docs/online-boutique-asm-manifests/base/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/base/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_online_boutique_asm_manifests_base_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -19,3 +20,4 @@ resources:
 components:
 - for-asm-channel
 - for-namespace
+# [END servicemesh_online_boutique_asm_manifests_base_kustomization_kustomization]

--- a/docs/online-boutique-asm-manifests/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_docs_online_boutique_asm_manifests_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -25,3 +26,4 @@ components:
 - authorization-policies/for-namespace
 - sidecars/all
 - sidecars/for-namespace
+# [END servicemesh_docs_online_boutique_asm_manifests_kustomization_kustomization]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_service_accounts_all_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
@@ -112,3 +113,4 @@ patchesJson6902:
     - op: replace
       path: /spec/template/spec/serviceAccountName
       value: shippingservice
+# [END servicemesh_service_accounts_all_kustomization_component]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/service-account-adservice.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/service-account-adservice.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_service_account_adservice_serviceaccount_adservice]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: adservice
+# [END servicemesh_all_service_account_adservice_serviceaccount_adservice]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/service-account-cartservice.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/service-account-cartservice.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_service_account_cartservice_serviceaccount_cartservice]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cartservice
+# [END servicemesh_all_service_account_cartservice_serviceaccount_cartservice]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/service-account-checkoutservice.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/service-account-checkoutservice.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_service_account_checkoutservice_serviceaccount_checkoutservice]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: checkoutservice
+# [END servicemesh_all_service_account_checkoutservice_serviceaccount_checkoutservice]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/service-account-currencyservice.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/service-account-currencyservice.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_service_account_currencyservice_serviceaccount_currencyservice]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: currencyservice
+# [END servicemesh_all_service_account_currencyservice_serviceaccount_currencyservice]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/service-account-emailservice.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/service-account-emailservice.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_service_account_emailservice_serviceaccount_emailservice]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: emailservice
+# [END servicemesh_all_service_account_emailservice_serviceaccount_emailservice]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/service-account-frontend.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/service-account-frontend.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_service_account_frontend_serviceaccount_frontend]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: frontend
+# [END servicemesh_all_service_account_frontend_serviceaccount_frontend]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/service-account-loadgenerator.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/service-account-loadgenerator.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_service_account_loadgenerator_serviceaccount_loadgenerator]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: loadgenerator
+# [END servicemesh_all_service_account_loadgenerator_serviceaccount_loadgenerator]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/service-account-paymentservice.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/service-account-paymentservice.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_service_account_paymentservice_serviceaccount_paymentservice]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: paymentservice
+# [END servicemesh_all_service_account_paymentservice_serviceaccount_paymentservice]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/service-account-productcatalogservice.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/service-account-productcatalogservice.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_service_account_productcatalogservice_serviceaccount_productcatalogservice]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: productcatalogservice
+# [END servicemesh_all_service_account_productcatalogservice_serviceaccount_productcatalogservice]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/service-account-recommendationservice.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/service-account-recommendationservice.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_service_account_recommendationservice_serviceaccount_recommendationservice]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: recommendationservice
+# [END servicemesh_all_service_account_recommendationservice_serviceaccount_recommendationservice]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/service-account-redis.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/service-account-redis.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_service_account_redis_serviceaccount_redis_cart]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: redis-cart
+# [END servicemesh_all_service_account_redis_serviceaccount_redis_cart]

--- a/docs/online-boutique-asm-manifests/service-accounts/all/service-account-shippingservice.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/all/service-account-shippingservice.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_service_account_shippingservice_serviceaccount_shippingservice]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: shippingservice
+# [END servicemesh_all_service_account_shippingservice_serviceaccount_shippingservice]

--- a/docs/online-boutique-asm-manifests/service-accounts/for-memorystore/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/for-memorystore/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_service_accounts_for_memorystore_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patchesStrategicMerge:
@@ -21,3 +22,4 @@ patchesStrategicMerge:
   metadata:
     name: redis-cart
   $patch: delete
+# [END servicemesh_service_accounts_for_memorystore_kustomization_component]

--- a/docs/online-boutique-asm-manifests/service-accounts/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/service-accounts/kustomization.yaml
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_online_boutique_asm_manifests_service_accounts_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base/all
 components:
 - all
+# [END servicemesh_online_boutique_asm_manifests_service_accounts_kustomization_kustomization]

--- a/docs/online-boutique-asm-manifests/sidecars/all/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_sidecars_all_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
@@ -27,3 +28,4 @@ resources:
 - sidecar-recommendationservice.yaml
 - sidecar-redis.yaml
 - sidecar-shippingservice.yaml
+# [END servicemesh_sidecars_all_kustomization_component]

--- a/docs/online-boutique-asm-manifests/sidecars/all/sidecar-adservice.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/sidecar-adservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_sidecar_adservice_sidecar_adservice]
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -23,3 +24,4 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+# [END servicemesh_all_sidecar_adservice_sidecar_adservice]

--- a/docs/online-boutique-asm-manifests/sidecars/all/sidecar-cartservice.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/sidecar-cartservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_sidecar_cartservice_sidecar_cartservice]
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -24,3 +25,4 @@ spec:
   - hosts:
     - istio-system/*
     - ./redis-cart.onlineboutique.svc.cluster.local
+# [END servicemesh_all_sidecar_cartservice_sidecar_cartservice]

--- a/docs/online-boutique-asm-manifests/sidecars/all/sidecar-checkoutservice.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/sidecar-checkoutservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_sidecar_checkoutservice_sidecar_checkoutservice]
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -29,3 +30,4 @@ spec:
     - ./paymentservice.onlineboutique.svc.cluster.local
     - ./productcatalogservice.onlineboutique.svc.cluster.local
     - ./shippingservice.onlineboutique.svc.cluster.local
+# [END servicemesh_all_sidecar_checkoutservice_sidecar_checkoutservice]

--- a/docs/online-boutique-asm-manifests/sidecars/all/sidecar-currencyservice.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/sidecar-currencyservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_sidecar_currencyservice_sidecar_currencyservice]
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -23,3 +24,4 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+# [END servicemesh_all_sidecar_currencyservice_sidecar_currencyservice]

--- a/docs/online-boutique-asm-manifests/sidecars/all/sidecar-emailservice.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/sidecar-emailservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_sidecar_emailservice_sidecar_emailservice]
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -23,3 +24,4 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+# [END servicemesh_all_sidecar_emailservice_sidecar_emailservice]

--- a/docs/online-boutique-asm-manifests/sidecars/all/sidecar-frontend.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/sidecar-frontend.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_sidecar_frontend_sidecar_frontend]
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -30,3 +31,4 @@ spec:
     - ./productcatalogservice.onlineboutique.svc.cluster.local
     - ./recommendationservice.onlineboutique.svc.cluster.local
     - ./shippingservice.onlineboutique.svc.cluster.local
+# [END servicemesh_all_sidecar_frontend_sidecar_frontend]

--- a/docs/online-boutique-asm-manifests/sidecars/all/sidecar-loadgenerator.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/sidecar-loadgenerator.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_sidecar_loadgenerator_sidecar_loadgenerator]
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -24,3 +25,4 @@ spec:
   - hosts:
     - istio-system/*
     - ./frontend.onlineboutique.svc.cluster.local
+# [END servicemesh_all_sidecar_loadgenerator_sidecar_loadgenerator]

--- a/docs/online-boutique-asm-manifests/sidecars/all/sidecar-paymentservice.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/sidecar-paymentservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_sidecar_paymentservice_sidecar_paymentservice]
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -23,3 +24,4 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+# [END servicemesh_all_sidecar_paymentservice_sidecar_paymentservice]

--- a/docs/online-boutique-asm-manifests/sidecars/all/sidecar-productcatalogservice.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/sidecar-productcatalogservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_sidecar_productcatalogservice_sidecar_productcatalogservice]
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -23,3 +24,4 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+# [END servicemesh_all_sidecar_productcatalogservice_sidecar_productcatalogservice]

--- a/docs/online-boutique-asm-manifests/sidecars/all/sidecar-recommendationservice.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/sidecar-recommendationservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_sidecar_recommendationservice_sidecar_recommendationservice]
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -24,3 +25,4 @@ spec:
   - hosts:
     - istio-system/*
     - ./productcatalogservice.onlineboutique.svc.cluster.local
+# [END servicemesh_all_sidecar_recommendationservice_sidecar_recommendationservice]

--- a/docs/online-boutique-asm-manifests/sidecars/all/sidecar-redis.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/sidecar-redis.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_sidecar_redis_sidecar_redis_cart]
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -23,3 +24,4 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+# [END servicemesh_all_sidecar_redis_sidecar_redis_cart]

--- a/docs/online-boutique-asm-manifests/sidecars/all/sidecar-shippingservice.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/all/sidecar-shippingservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_all_sidecar_shippingservice_sidecar_shippingservice]
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -23,3 +24,4 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+# [END servicemesh_all_sidecar_shippingservice_sidecar_shippingservice]

--- a/docs/online-boutique-asm-manifests/sidecars/for-memorystore/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/for-memorystore/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_sidecars_for_memorystore_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patchesJson6902:
@@ -30,3 +31,4 @@ patchesStrategicMerge:
   metadata:
     name: redis-cart
   $patch: delete
+# [END servicemesh_sidecars_for_memorystore_kustomization_component]

--- a/docs/online-boutique-asm-manifests/sidecars/for-namespace/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/for-namespace/kustomization.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_sidecars_for_namespace_kustomization_component]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patchesJson6902:
@@ -71,3 +72,4 @@ patchesJson6902:
       value:
         - istio-system/*
         - ./productcatalogservice.ONLINEBOUTIQUE_NAMESPACE.svc.cluster.local
+# [END servicemesh_sidecars_for_namespace_kustomization_component]

--- a/docs/online-boutique-asm-manifests/sidecars/kustomization.yaml
+++ b/docs/online-boutique-asm-manifests/sidecars/kustomization.yaml
@@ -1,3 +1,4 @@
+
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START servicemesh_online_boutique_asm_manifests_sidecars_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:
 - all
 - for-namespace
+# [END servicemesh_online_boutique_asm_manifests_sidecars_kustomization_kustomization]


### PR DESCRIPTION

### fixes issue https://github.com/GoogleCloudPlatform/anthos-service-mesh-samples/issues/45
Region tagging the newly added files related to https://github.com/GoogleCloudPlatform/anthos-service-mesh-samples/pull/43 
I'm assuming `docs/online-boutique-asm-manifests/base/all/kubernetes-manifests.yaml` is copy pasta 🍝  from online-boutique, so I skipped region tagging that

Once merged, I'll monitor for when the region tags appear internally