### PR TITLE
Change Online Boutique Service to ClusterIP

### DIFF
--- a/docs/shared/online-boutique/kubernetes-manifests.yaml
+++ b/docs/shared/online-boutique/kubernetes-manifests.yaml
@@ -293,7 +293,7 @@ kind: Service
 metadata:
   name: frontend-external
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: frontend
   ports:


### PR DESCRIPTION
### Background 
* Services of type `LoadBalancer` get assigned public IP addresses.
* But whenever we deploy Online Boutique on a cluster with ASM, we rely on the ASM ingress gateway to handle public traffic.

### Fixes 
* A public IP address is no longer generated for the `frontend` Service of Online Boutique.

### Change Summary
* The Online Boutique `frontend` Service's `type` is changed from `LoadBalancer` to `ClusterIP`.

### Additional Notes
* `ClusterIP` is used in https://github.com/GoogleCloudPlatform/anthos-service-mesh-samples/blob/main/docs/online-boutique-asm-manifests/base/all/kubernetes-manifests.yaml.

### Testing Procedure
If you'd like to be rigorous in your review, you can deploy the following in a cluster with ASM:
```
kubectl apply -f docs/shared/online-boutique/virtual-service.yaml
kubectl apply -f docs/shared/online-boutique/kubernetes-manifests.yaml
```

### Related PRs or Issues 
N/A