### PR TITLE
Specifying machine type in ASM GKE Hub resources

### DIFF
--- a/docs/asm-gke-terraform/main.tf
+++ b/docs/asm-gke-terraform/main.tf
@@ -7,22 +7,12 @@ resource "google_container_cluster" "cluster" {
   workload_identity_config {
     workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
   }
-
-  depends_on = [
-    google_project_service.project
-  ]
-}
-
-resource "google_container_node_pool" "my_cluster_nodes" {
-  project    = var.project_id
-  name       = "my-node-pool"
-  location   = var.zone
-  cluster    = google_container_cluster.cluster.name
-  node_count = 1
-
   node_config {
     machine_type = "e2-standard-4"
   }
+  depends_on = [
+    google_project_service.project
+  ]
 }
 data "google_project" "project" {
   project_id = var.project_id

--- a/docs/asm-gke-terraform/main.tf
+++ b/docs/asm-gke-terraform/main.tf
@@ -7,9 +7,22 @@ resource "google_container_cluster" "cluster" {
   workload_identity_config {
     workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
   }
+
   depends_on = [
     google_project_service.project
   ]
+}
+
+resource "google_container_node_pool" "my_cluster_nodes" {
+  project    = var.project_id
+  name       = "my-node-pool"
+  location   = var.zone
+  cluster    = google_container_cluster.cluster.name
+  node_count = 1
+
+  node_config {
+    machine_type = "e2-standard-4"
+  }
 }
 data "google_project" "project" {
   project_id = var.project_id
@@ -35,8 +48,8 @@ resource "google_gke_hub_feature" "feature" {
 }
 
 resource "google_gke_hub_feature_membership" "feature_member" {
-  location = "global"
-  feature = google_gke_hub_feature.feature.name
+  location   = "global"
+  feature    = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   mesh {
     management = "MANAGEMENT_AUTOMATIC"


### PR DESCRIPTION
### Background 
Adding the `e2-standard-4` in the ASM TF GKE Hub way of provisioning managed ASM

### Fixes 
<!-- Link the issue(s) this PR fixes-->

### Change Summary
<!-- Short summary of the changes submitted -->

### Additional Notes
<!-- Any remaining concerns -->

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->