### PR TITLE
Remove Role/RoleBinding not used as part of the ASM/ACM tuto

### DIFF
--- a/docs/ingress-gateway-asm-manifests/base/deployment-service.yaml
+++ b/docs/ingress-gateway-asm-manifests/base/deployment-service.yaml
@@ -103,28 +103,3 @@ spec:
     kind: Deployment
     name: asm-ingressgateway
 # [END servicemesh_base_deployment_service_hpa_asm_ingressgateway]
----
-# [START servicemesh_base_deployment_service_role_asm_ingressgateway]
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: asm-ingressgateway
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "watch", "list"]
-# [END servicemesh_base_deployment_service_role_asm_ingressgateway]
----
-# [START servicemesh_base_deployment_service_rolebinding_asm_ingressgateway]
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: asm-ingressgateway
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: asm-ingressgateway
-subjects:
-  - kind: ServiceAccount
-    name: asm-ingressgateway
-# [END servicemesh_base_deployment_service_rolebinding_asm_ingressgateway]


### PR DESCRIPTION
Remove `Role`/`RoleBinding` not used as part of the ASM/ACM tuto + avoid issue with asm-ingress being synced by `RepoSync` without the proper `RoleBinding`:
```
KNV2009: polling for status failed: failed to list rbac.authorization.k8s.io/v1, Kind=Role: roles.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:config-management-system:ns-reconciler-asm-ingress" cannot list resource "roles" in API group "rbac.authorization.k8s.io" in the namespace "asm-ingress"
```