### PR TITLE
Create virtual-service-in-cluster-asm.yaml

### DIFF
--- a/docs/migrate-to-managed-asm/virtual-service-in-cluster-asm.yaml
+++ b/docs/migrate-to-managed-asm/virtual-service-in-cluster-asm.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START servicemesh_migrate_to_managed_asm_virtual_service_virtualservice_frontend_ingress]
+# [START servicemesh_migrate_to_managed_asm_virtual_service_in_cluster_asm_virtualservice_frontend_ingress]
 # This VirtualService splits HTTP traffic coming into the cluster you're migrating away from.
 # This VirtualService ensures that the traffic will be shared between both clusters.
 apiVersion: networking.istio.io/v1alpha3
@@ -36,4 +36,4 @@ spec:
           number: 80
         host: v2.example.com # The temporary domain name of the frontend inside the cluster with managed ASM.
       weight: 50
-# [END servicemesh_migrate_to_managed_asm_virtual_service_virtualservice_frontend_ingress]
+# [END servicemesh_migrate_to_managed_asm_virtual_service_in_cluster_asm_virtualservice_frontend_ingress]

--- a/docs/migrate-to-managed-asm/virtual-service-in-cluster-asm.yaml
+++ b/docs/migrate-to-managed-asm/virtual-service-in-cluster-asm.yaml
@@ -1,0 +1,39 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START servicemesh_migrate_to_managed_asm_virtual_service_virtualservice_frontend_ingress]
+# This VirtualService splits HTTP traffic coming into the cluster you're migrating away from.
+# This VirtualService ensures that the traffic will be shared between both clusters.
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: frontend
+spec:
+  gateways:
+  - asm-ingress/asm-ingressgateway
+  hosts:
+  - '*' # In production, be more specific.
+  http:
+  - route:
+    - destination:
+        port:
+          number: 80
+        host: frontend # The name of the Service inside the cluster you're migrating away from.
+      weight: 50
+    - destination:
+        port:
+          number: 80
+        host: v2.example.com # The temporary domain name of the frontend inside the cluster with managed ASM.
+      weight: 50
+# [END servicemesh_migrate_to_managed_asm_virtual_service_virtualservice_frontend_ingress]


### PR DESCRIPTION
### Background 
* See Google-internal changelist, [cl/491941189](http://cl/491941189) (**in-cluster**-to-managed-ASM migration tutorial).
* For the **in-cluster**-to-managed-ASM migration tutorial, we cannot re-use the VirtualService that's being used in the **Istio**-to-managed-ASM migration tutorial.
* The **Istio**-to-managed-ASM migration tutorial uses [`/docs/migrate-to-managed-asm/virtual-service.yaml`](https://github.com/GoogleCloudPlatform/anthos-service-mesh-samples/blob/main/docs/migrate-to-managed-asm/virtual-service.yaml).

### Change Summary
Introduce a new/separate `VirtualService` for the **in-cluster**-to-managed-ASM migration tutorial.

### Testing Procedure
I have deployed this new VirtualService to a cluster with in-cluster ASM.
Find the [IP address in this Google-internal Google Doc](https://docs.google.com/document/d/1Ige1eZR7TkcuJ6toU4W_dbTBo9NA0wKQVM7TWgYoBq8/edit?usp=sharing&resourcekey=0-XuVsC1NxZt5VajXL8fds2w).
