### PR TITLE
Change the cluster name for TF

### DIFF
--- a/docs/asm-gke-terraform/main.tf
+++ b/docs/asm-gke-terraform/main.tf
@@ -1,5 +1,5 @@
 resource "google_container_cluster" "cluster" {
-  name               = "my-cluster"
+  name               = "asm-cluster"
   location           = var.zone
   initial_node_count = 1
   provider           = google-beta


### PR DESCRIPTION
### Background 
The cluster name by default was `my-cluster` for the ASM TF quickstart. What a detailed and descriptive name lol.

### Fixes 
<!-- Link the issue(s) this PR fixes-->

### Change Summary
`my-cluster` --> `asm-cluster`

### Additional Notes
n/a!

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->