### PR TITLE
Update and rename autoscaling-v2beta1.yaml to autoscaling-v2.yaml

### DIFF
--- a/docs/shared/asm-ingress-gateway/autoscaling-v2.yaml
+++ b/docs/shared/asm-ingress-gateway/autoscaling-v2.yaml
@@ -1,7 +1,6 @@
 # Optional: HorizontalPodAutoscaler will automatically scale the gateway replica count based on
 # CPU utilization
-# Used on <1.23 K8S versions
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: istio-ingressgateway


### PR DESCRIPTION
Updating the now unsupported autoscaling-v2beta1.yaml to use the supported v2

### Background 
Following the [ASM Authorization tutorial](https://cloud.google.com/service-mesh/docs/by-example/authz#deploy_an_ingress_gateway) results in this error: `error: resource mapping not found for name: "istio-ingressgateway" namespace: "" from "docs/shared/asm-ingress-gateway/autoscaling-v2beta1.yaml": no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2beta1"` 

### Change Summary
Changes autoscaling/v2beta1 to autoscaling/v2