### PR TITLE
Update autoscaling-v2.yaml

### DIFF
--- a/docs/shared/asm-ingress-gateway/autoscaling-v2.yaml
+++ b/docs/shared/asm-ingress-gateway/autoscaling-v2.yaml
@@ -7,10 +7,12 @@ metadata:
 spec:
   maxReplicas: 5
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 80
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 80
   minReplicas: 3
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
### Background 
My last change introduced a new error:

`strict decoding error: unknown field "spec.metrics[0].resource.targetAverageUtilization"`

### Change Summary
This formatting fix prevents that new error and lets the users progress through the tutorials as expected