### PR TITLE
Move helloserver from istio-samples

### DIFF
--- a/docs/helloserver/README.md
+++ b/docs/helloserver/README.md
@@ -1,0 +1,9 @@
+## Sample App: helloserver 
+
+The `helloserver` application is a small sample application designed to be used for "hello world" Istio demos. 
+
+The application consists of two services:
+1) `helloserver`, a tiny HTTP server written in Python. The `GET /` endpoint returns `hello world` 
+2) `loadgen`, a Python script that can generate a configurable number of requests to `helloserver`. The loadgen is designed to generate observability metrics for Istio and Kiali.   
+
+For a more complex microservices example, see the [Hipstershop Demo](https://github.com/GoogleCloudPlatform/microservices-demo).

--- a/docs/helloserver/README.md
+++ b/docs/helloserver/README.md
@@ -1,9 +1,9 @@
 ## Sample App: helloserver 
 
-The `helloserver` application is a small sample application designed to be used for "hello world" Istio demos. 
+The `helloserver` application is a small sample application designed to be used for "hello world" ASM or Istio demos. 
 
 The application consists of two services:
 1) `helloserver`, a tiny HTTP server written in Python. The `GET /` endpoint returns `hello world` 
 2) `loadgen`, a Python script that can generate a configurable number of requests to `helloserver`. The loadgen is designed to generate observability metrics for Istio and Kiali.   
 
-For a more complex microservices example, see the [Hipstershop Demo](https://github.com/GoogleCloudPlatform/microservices-demo).
+For a more complex microservices example, see [microservices-demo](https://github.com/GoogleCloudPlatform/microservices-demo).

--- a/docs/helloserver/loadgen/Dockerfile
+++ b/docs/helloserver/loadgen/Dockerfile
@@ -1,0 +1,16 @@
+FROM gcr.io/google-samples/istio-samples/helloserver/loadgen-base as final
+
+# Enable unbuffered logging
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get -qq update \
+    && apt-get install -y --no-install-recommends \
+        wget
+
+WORKDIR /loadgen
+
+# Add the application
+COPY . .
+
+EXPOSE 8080
+ENTRYPOINT [ "python", "loadgen.py" ]

--- a/docs/helloserver/loadgen/Dockerfile-base
+++ b/docs/helloserver/loadgen/Dockerfile-base
@@ -1,0 +1,10 @@
+FROM python:3-slim as builder
+
+RUN apt-get -qq update \
+    && apt-get install -y --no-install-recommends \
+        g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# get packages
+COPY requirements.txt .
+RUN pip install -r requirements.txt

--- a/docs/helloserver/loadgen/loadgen.py
+++ b/docs/helloserver/loadgen/loadgen.py
@@ -1,0 +1,53 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import datetime
+import schedule
+import os
+import time
+import grequests
+
+def exception_handler(request, exception):
+    print("Request failed: %s" % exception)
+
+
+def callserver():
+    urls = [url]*c  # number of concurrent requests per second
+
+    rs = (grequests.get(u) for u in urls)
+    grequests.map(rs, exception_handler=exception_handler)
+    print("%s request(s) complete to %s" % (c, url))
+
+
+# start loadgen
+url = os.getenv('SERVER_ADDR')
+if url is None:
+   print("SERVER_ADDR env variable is not defined")
+   exit(1)
+
+c_str = os.getenv('REQUESTS_PER_SECOND')
+if c_str is None:
+   print("REQUESTS_PER_SECOND env variable is not defined")
+   exit(1)
+
+c = int(c_str)
+
+now = datetime.datetime.now()
+print("🚀 Starting loadgen: %s" % now)
+schedule.every(1).seconds.do(callserver)
+
+while 1:
+   schedule.run_pending()
+   time.sleep(1)

--- a/docs/helloserver/loadgen/loadgen.yaml
+++ b/docs/helloserver/loadgen/loadgen.yaml
@@ -1,0 +1,65 @@
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START istio_helloserver_loadgen_deployment_loadgenerator]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadgenerator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loadgenerator
+  template:
+    metadata:
+      labels:
+        app: loadgenerator
+    spec:
+      containers:
+      - env:
+        - name: SERVER_ADDR
+          value: http://hellosvc:80/
+        - name: REQUESTS_PER_SECOND
+          value: '10'
+        image: gcr.io/google-samples/istio/loadgen:v0.0.1
+        imagePullPolicy: Always
+        name: main
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 300m
+            memory: 256Mi
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 5
+# [END istio_helloserver_loadgen_deployment_loadgenerator]
+---
+# [START istio_helloserver_loadgen_service_loadgensvc]
+apiVersion: v1
+kind: Service
+metadata:
+  name: loadgensvc
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    app: loadgenerator
+  type: ClusterIP
+# [END istio_helloserver_loadgen_service_loadgensvc]
+---

--- a/docs/helloserver/loadgen/loadgen.yaml
+++ b/docs/helloserver/loadgen/loadgen.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START istio_helloserver_loadgen_deployment_loadgenerator]
+# [START servicemesh_helloserver_loadgen_deployment_loadgenerator]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,9 +46,9 @@ spec:
             memory: 256Mi
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
-# [END istio_helloserver_loadgen_deployment_loadgenerator]
+# [END servicemesh_helloserver_loadgen_deployment_loadgenerator]
 ---
-# [START istio_helloserver_loadgen_service_loadgensvc]
+# [START servicemesh_helloserver_loadgen_service_loadgensvc]
 apiVersion: v1
 kind: Service
 metadata:
@@ -61,5 +61,5 @@ spec:
   selector:
     app: loadgenerator
   type: ClusterIP
-# [END istio_helloserver_loadgen_service_loadgensvc]
+# [END servicemesh_helloserver_loadgen_service_loadgensvc]
 ---

--- a/docs/helloserver/loadgen/requirements.txt
+++ b/docs/helloserver/loadgen/requirements.txt
@@ -1,0 +1,3 @@
+grequests==0.3.0
+requests==2.22.0
+schedule==0.6.0

--- a/docs/helloserver/server/Dockerfile
+++ b/docs/helloserver/server/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.9-slim as base
+FROM base as builder
+RUN apt-get -qq update \
+    && apt-get install -y --no-install-recommends \
+        g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Enable unbuffered logging
+FROM base as final
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get -qq update \
+    && apt-get install -y --no-install-recommends \
+        wget
+
+WORKDIR /helloserver
+
+# Grab packages from builder
+COPY --from=builder /usr/local/lib/python3.9/ /usr/local/lib/python3.9/
+
+# Add the application
+COPY . .
+
+EXPOSE 8080
+ENTRYPOINT [ "python", "server.py" ]

--- a/docs/helloserver/server/server.py
+++ b/docs/helloserver/server/server.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import logging
+
+class S(BaseHTTPRequestHandler):
+    def _set_response(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_GET(self):
+        logging.info("GET request,\nPath: %s\nHeaders:\n%s\n", str(self.path), str(self.headers))
+        self._set_response()
+        self.wfile.write("Hello World! {}".format(self.path).encode('utf-8'))
+
+# HTTP Server runs on port 8080
+def run(server_class=HTTPServer, handler_class=S, port=8080):
+    logging.basicConfig(level=logging.INFO)
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    logging.info('Starting server...\n')
+
+    # start listening
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+    logging.info('Stopping...\n')
+
+if __name__ == '__main__':
+    from sys import argv
+
+    if len(argv) == 2:
+        run(port=int(argv[1]))
+    else:
+        run()

--- a/docs/helloserver/server/server.yaml
+++ b/docs/helloserver/server/server.yaml
@@ -1,0 +1,53 @@
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START istio_helloserver_server_deployment_helloserver]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helloserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: helloserver
+  template:
+    metadata:
+      labels:
+        app: helloserver
+    spec:
+      containers:
+      - image: gcr.io/google-samples/istio/helloserver:v0.0.1
+        imagePullPolicy: Always
+        name: main
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 5
+# [END istio_helloserver_server_deployment_helloserver]
+---
+# [START istio_helloserver_server_service_hellosvc]
+apiVersion: v1
+kind: Service
+metadata:
+  name: hellosvc
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    app: helloserver
+  type: LoadBalancer
+# [END istio_helloserver_server_service_hellosvc]
+---

--- a/docs/helloserver/server/server.yaml
+++ b/docs/helloserver/server/server.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START istio_helloserver_server_deployment_helloserver]
+# [START servicemesh_helloserver_server_deployment_helloserver]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,9 +34,9 @@ spec:
         name: main
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
-# [END istio_helloserver_server_deployment_helloserver]
+# [END servicemesh_helloserver_server_deployment_helloserver]
 ---
-# [START istio_helloserver_server_service_hellosvc]
+# [START servicemesh_helloserver_server_service_hellosvc]
 apiVersion: v1
 kind: Service
 metadata:
@@ -49,5 +49,5 @@ spec:
   selector:
     app: helloserver
   type: LoadBalancer
-# [END istio_helloserver_server_service_hellosvc]
+# [END servicemesh_helloserver_server_service_hellosvc]
 ---


### PR DESCRIPTION
This PR migrates the `helloserver` [app](https://github.com/GoogleCloudPlatform/istio-samples/tree/master/sample-apps/helloserver) from the deprecated istio-samples repo (https://github.com/GoogleCloudPlatform/istio-samples).