### PR TITLE
fix(helloserver): use wildcard for python3.x library copy

### DIFF
--- a/docs/helloserver/server/Dockerfile
+++ b/docs/helloserver/server/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -qq update \
 WORKDIR /helloserver
 
 # Grab packages from builder
-COPY --from=builder /usr/local/lib/python3.9/ /usr/local/lib/python3.9/
+COPY --from=builder /usr/local/lib/python3.* /usr/local/lib/
 
 # Add the application
 COPY . .


### PR DESCRIPTION
### Background 
Fixes mismatch between Renovate-updated base image, and the directory in which
libraries are stored. Using a wildcard should catch all minor version changes.
No other python versions are present in the base image, so no additional data is
copied.

### Fixes 
Fixes #210

### Testing Procedure

Tested via local build and docker run
