### PR TITLE
fix: Set deletion_protection to false for GKE clusters

### DIFF
--- a/demos/asm-mcp-multi-clusters/terraform/main.tf
+++ b/demos/asm-mcp-multi-clusters/terraform/main.tf
@@ -35,11 +35,12 @@ resource "google_storage_bucket" "lab_materials" {
 
 # GKE Clusters
 resource "google_container_cluster" "cluster1" {
-  name               = var.cluster1
-  location           = var.cluster1_location
-  initial_node_count = var.cluster_node_count
-  resource_labels    = { "mesh_id" : "proj-${data.google_project.project_id.number}" }
-  networking_mode    = "VPC_NATIVE"
+  name                = var.cluster1
+  location            = var.cluster1_location
+  initial_node_count  = var.cluster_node_count
+  resource_labels     = { "mesh_id" : "proj-${data.google_project.project_id.number}" }
+  networking_mode     = "VPC_NATIVE"
+  deletion_protection = false # Warning: Do not set deletion_protection to false for production clusters
 
   ip_allocation_policy {
     cluster_ipv4_cidr_block  = "" // use default values

--- a/docs/asm-gke-terraform/main.tf
+++ b/docs/asm-gke-terraform/main.tf
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 resource "google_container_cluster" "cluster" {
-  name               = "asm-cluster"
-  location           = var.zone
-  initial_node_count = 1
-  provider           = google-beta
-  resource_labels    = { mesh_id : "proj-${data.google_project.project.number}" }
+  name                = "asm-cluster"
+  location            = var.zone
+  initial_node_count  = 1
+  provider            = google-beta
+  resource_labels     = { mesh_id : "proj-${data.google_project.project.number}" }
+  deletion_protection = false # Warning: Do not set deletion_protection to false for production clusters
   workload_identity_config {
     workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
   }

--- a/docs/terraform-asm-mcp/gke.tf
+++ b/docs/terraform-asm-mcp/gke.tf
@@ -41,6 +41,7 @@ module "gke" {
   enable_private_nodes    = false
   master_ipv4_cidr_block  = "172.16.0.0/28"
   cluster_resource_labels = { "mesh_id" : "proj-${data.google_project.project.number}" }
+  deletion_protection     = false # Warning: Do not set deletion_protection to false for production clusters
   depends_on = [
     module.enable_google_apis
   ]


### PR DESCRIPTION
*  The `google` Terraform provider (in v5.0.0) introduced the `deletion_protection` variable for the `google_container_cluster` resource.
* This value defaults to `true`, which means, during `terraform destroy` users will need to
    1. Manually set `deletion_protection` to `false`
    2. Re-run `terraform apply`
    3. Finally, run `terraform destroy`
* In my opinion, the simplest way for use to tackle this issue is just to set `deletion_protection` to `false` from the start (in the Terraform code), with an in-code warning about not using this in production.

### Alternative approach
* Alternatively, we could also add a note next to `terraform destroy` instructions, but this adds more friction for our users.
* That said, I am open to changing my approach here! :)

### More info
* From [Terraform docs for `google_container_cluster`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster):
> On version 5.0.0+ of the provider, you must explicitly set deletion_protection=false (and run terraform apply to write the field to state) in order to destroy a cluster. It is recommended to not set this field (or set it to true) until you're ready to destroy.