### PR TITLE
Use a GKE Autopilot cluster for ASM sample

### DIFF
--- a/docs/asm-gke-terraform/variables.tf
+++ b/docs/asm-gke-terraform/variables.tf
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "zone" {
+variable "region" {
   type        = string
-  default     = "us-central1-a"
-  description = "The zone to host the cluster in (required if is a zonal cluster)"
+  default     = "us-central1"
+  description = "The region to host the cluster in (Autopilot clusters are always regional)"
 }


### PR DESCRIPTION
### Change Summary

* Switch to Autopilot mode. It should be the default for GKE.
* Gave the mesh API resource a better name (mesh_api).
* Removed unnecessary mesh API dependency from GKE cluster resource.

### Testing Procedure
`terraform apply` on a clean project (tested)

