### PR TITLE
Cluster is added to fleet during creation

### DIFF
--- a/docs/asm-gke-terraform/providers.tf
+++ b/docs/asm-gke-terraform/providers.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.5"
+      version = "~> 5.8"
     }
   }
 }


### PR DESCRIPTION


### Background 

Cluster is added to fleet during creation. The membership created by the cluster API is a regional membership.

Previously, the membership was being created separately after cluster creation but using a "global" membership.

The official ASM onboarding documentation uses "born-in-fleet" clusters, which create regional memberships. The "google" provider added support for regional membership features in 5.8.0. This sample now aligns with the official documentation.

### Change Summary
* Use the `fleet` block on `google_container_cluster` to add the cluster to the cluster project's fleet when the cluster is created.
* `google_gke_hub_membership` is no longer required - membership can be referenced via cluster.
* Use the new `membership_location` attribute on `google_gke_hub_feature_membership` because the membership is regional.
* Updated provider to 5.8.x to be able to use the above `membership_location` attribute.

### Testing Procedure
terraform apply
