### PR TITLE
Removed obsolete 'mesh_id' label

### DIFF
--- a/docs/asm-gke-terraform/main.tf
+++ b/docs/asm-gke-terraform/main.tf
@@ -16,7 +16,6 @@
 resource "google_container_cluster" "cluster" {
   name                = "asm-cluster"
   location            = var.region
-  resource_labels     = { mesh_id : "proj-${data.google_project.project.number}" }
   deletion_protection = false # Warning: Do not set deletion_protection to false for production clusters
 
   enable_autopilot = true


### PR DESCRIPTION
### Background 
Removed the `mesh_id` label because it is no longer required when installing Anthos Service mesh using the Fleet API. Previously it was needed to consolidate telemetry from multiple clusters in the UI.

### Testing Procedure
`terraform apply` - tested cluster and mesh with test apps - verfiied telemetry is correctly displayed in UI.