### PR TITLE
Use v1beta1 networking apis instead of v1alpha3

### DIFF
--- a/docs/canary-service/destination-v1-v2.yaml
+++ b/docs/canary-service/destination-v1-v2.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # [START servicemesh_canary_service_destination_v1_v2_destinationrule_productcatalogservice]
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   name: productcatalogservice

--- a/docs/canary-service/destination-vs-v1.yaml
+++ b/docs/canary-service/destination-vs-v1.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # [START servicemesh_canary_service_destination_vs_v1_destinationrule_productcatalogservice]
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   name: productcatalogservice
@@ -27,7 +27,7 @@ spec:
 # [END servicemesh_canary_service_destination_vs_v1_destinationrule_productcatalogservice]
 ---
 # [START servicemesh_canary_service_destination_vs_v1_virtualservice_productcatalogservice]
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: productcatalogservice

--- a/docs/canary-service/vs-split-traffic.yaml
+++ b/docs/canary-service/vs-split-traffic.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # [START servicemesh_canary_service_vs_split_traffic_virtualservice_productcatalogservice]
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: productcatalogservice

--- a/docs/canary-service/vs-v1.yaml
+++ b/docs/canary-service/vs-v1.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # [START servicemesh_canary_service_rollback_virtualservice_productcatalogservice]
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: productcatalogservice

--- a/docs/canary-service/vs-v2.yaml
+++ b/docs/canary-service/vs-v2.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # [START servicemesh_canary_service_rollout_virtualservice_productcatalogservice]
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: productcatalogservice


### PR DESCRIPTION
### Background 

We use the alpha versions of APIs, but we should use the promoted ones.

### Fixes 
N/A

### Change Summary
Use v1beta1 networking APIs instead of v1alpha3.

### Additional Notes
N/A

### Testing Procedure
Not tested. This should be a trivial change.

### Related PRs or Issues 
N/A