### PR TITLE
fix: Rebuild and repush base image for helloserver/loadgen

### DIFF
--- a/docs/helloserver/loadgen/Dockerfile
+++ b/docs/helloserver/loadgen/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google-samples/istio-samples/helloserver/loadgen-base as final
+FROM us-docker.pkg.dev/google-samples/containers/csm/helloserver/loadgen-base as final
 
 # Enable unbuffered logging
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
### Background 
* The `helloserver/loadgen` image is used by this tutorial: [Prepare an application for Cloud Service Mesh](https://cloud.google.com/service-mesh/docs/prepare-app-for-anthos-service-mesh).
* Currently, when you try to build the `helloserver/loadgen` image, you get the following error:
```
=> ERROR [2/4] RUN apt-get -qq update     && apt-get install -y --no-install-recommends         wget                                   1.7s
------
 > [2/4] RUN apt-get -qq update     && apt-get install -y --no-install-recommends         wget:
1.616 W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
1.616 W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
1.616 W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
1.616 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.2.132 80]
1.616 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found [IP: 151.101.2.132 80]
1.616 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.2.132 80]
1.616 E: Some index files failed to download. They have been ignored, or old ones used instead.
------

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
Dockerfile:6
--------------------
   5 |     
   6 | >>> RUN apt-get -qq update \
   7 | >>>     && apt-get install -y --no-install-recommends \
   8 | >>>         wget
   9 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get -qq update     && apt-get install -y --no-install-recommends         wget" did not complete successfully: exit code: 100
```

### Change Summary
* I've rebuilt the `Dockerfile-base` image and pushed it to `us-docker.pkg.dev/google-samples/containers/csm/helloserver/loadgen-base`.
* I've updated `Dockerfile` to use this new base image (FROM `us-docker.pkg.dev/google-samples/containers/csm/helloserver/loadgen-base`).

### Testing Procedure
I have tested `docker build`-ing of both Dockerfiles locally. They work.
